### PR TITLE
1.2.1 Hidden audio sessions, new profiles, better overlay.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 1.2.0
 *Version bump from 1.0.x to 1.2.x is caused by GitHub branch name being called 1.1.x and package version not following that.*
 ## Updates
-
+- Moving all audio related logic from MainWindow to AudioViewer (no regression allowed).
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 # Change log
 
-## **1.2.0**
+# 1.2.0
 *Version bump from 1.0.x to 1.2.x is caused by GitHub branch name being called 1.1.x and package version not following that.*
-### Updates
+## Updates
 
 
-### Fixes
+## Fixes
 
 
-### Bugs
+## Bugs
 - Audio session volume icon is not green when the audio session is active in vertical layout.
 - Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
 - On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
 
-### Todo
+## Todo
 - [ ] Show/hide audio sessions.
 - [ ] Enable the user to change hot key key, not only modifiers.
 - [ ] Add more hot keys (audio session control, reload, restart, show on current screen, PiP).
@@ -32,8 +32,8 @@
 
 
 
-## **1.0.6**
-### Updates
+# 1.0.6
+## Updates
 - The user can no longer choose if he wants to use a custom title bar or not.
 - Changed `MOVE_WINDOW` hot key from `Ctrl + F1` to `Alt + A`.
 - Overlay window position and size can be set from settings (new overlay settings page).
@@ -41,14 +41,14 @@
 - Updated NumberBlock to set the number of decimals desired.
 - Re-added `update_notes.json` for i18ed update notes.
 
-### Fixes
+## Fixes
 - Finished translating settings page.
 
-### Bugs
+## Bugs
 - Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
 - On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
 
-### Todo
+## Todo
 - [ ] Show/hide audio sessions.
 - [X] Re-implement I18Ned "What's new" page.
 - [ ] Enable the user to change hot key key, not only modifiers.
@@ -68,19 +68,19 @@
 
 
 
-## **1.0.5**
-### Updates
+# 1.0.5
+## Updates
 - Added overlay mode, unresizable window with no close/minimize/maximize button.
 - Added indicators to show how many audio sessions the window can currently host (on the right and on the top).
 
-### Fixes
+## Fixes
 - Fixed "Show inactive audio sessions on startup" being defaulted to false (when starting the app for the first time). It is now defaulted to true.
 
-### Bugs
+## Bugs
 - Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
 - On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
 
-### Todo
+## Todo
 - [ ] Show/hide audio sessions.
 - [ ] Re-implement I18Ned "What's new" page.
 - [ ] Enable the user to change hot key key, not only modifiers.
@@ -89,21 +89,21 @@
 
 
 
-## **1.0.4**
-### Updates
+# 1.0.4
+## Updates
 - Added overlay mode, unresizable window with no close/minimize/maximize button.
 - Updated hot keys so that their modifier can be modified by the user. The user will be able to edit the key in future updates.
 - Adding new translations to all menus, starting with the main window.
 - Translations added to other menus.
 - Added indicators to show how many audio sessions the window can currently host (on the right and on the top).
 
-### Fixes
+## Fixes
 
-### Bugs
+## Bugs
 - Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
 - On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
 
-### Todo
+## Todo
 - [x] Disable/enable hot keys.
 - [ ] Show/hide audio sessions.
 - [ ] Re-implement I18Ned "What's new" page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,15 @@
-# Change log
+# *Change log*
 
-# 1.2.0
-*Version bump from 1.0.x to 1.2.x is caused by GitHub branch name being called 1.1.x and package version not following that.*
+# 1.2.1
 ## Updates
-- Moving all audio related logic from MainWindow to AudioViewer (no regression allowed).
+- Added background color (in `OverlaySettingsPage`) to see the size of the screen.
 
 ## Fixes
 
-
 ## Bugs
-- Audio session volume icon is not green when the audio session is active in vertical layout.
 - Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
 - On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
+- Some I18Ned applications don't have a real name: "ms-resource:AppStoreName".
 
 ## Todo
 - [ ] Show/hide audio sessions.
@@ -28,7 +26,63 @@
     - [ ] Audio profiles pages.
     - [ ] Audio sessions page.
     - [ ] Overlay page.
-- [ ] Move audio controls to AudioViewer.
+- [ ] Change app logo to be the 'audio mixer' font icon.
+- [ ] Handle `ms-resources` when reading package information from app manifests.
+- [ ] Invalidate and release all audio objects when bug #2 occurs. This will allow the application to reload audio sessions without having to restart.
+- [ ] Implement `AudioProfileEditPage` exit confirmation dialog (changes check not done).
+- [ ] Fix overlay settings not properly working.
+
+
+# 1.2.0
+*Version bump from 1.0.x to 1.2.x is caused by GitHub branch name being called 1.1.x and package version not following that.*
+## Updates
+- Moving all audio related logic from MainWindow to AudioViewer (no regression allowed).
+- Split user profile in 2:
+    - UserProfile to store window properties, overlay settings and stuff like that.
+    - AudioProfile to store all audio related settings.
+*-> this change was needed to have more flexibility and to clearly split responsabilities between `MainWindow` and `AudioViewer`.*
+- Added `UserProfile` to save window and app related settings. `AudioProfile` now handles only audio related settings.
+- Removed app/window related settings from `AudioProfile` (ie `IsAlwaysOnTop`, `WindowDisplayRect`).
+- Moved MessageBar to the bottom to replicate Youtube's mobile app notifications (and updating animations accordingly).
+- Updated `ToggleButton` to use `IInspectable` (to display generic content) for `OnIcon` and `OffIcon`. It might be changed back to `hstring` since icon composition is not that useful.
+- `OverlaySettingsPage` now adds itself to the navigation breadcrumbs.
+
+## Fixes
+- Fixed audio sessions being added even if another session with the same grouping parameter.
+- Fixed `Audio session volume icon is not green when the audio session is active in vertical layout.`
+- Fixed `ToggleIconButton` not properly behaving on pointer over by setting its background.
+
+## Bugs
+- Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
+- On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
+- Some I18Ned applications don't have a real name: "ms-resource:AppStoreName".
+
+## Todo
+- [ ] Show/hide audio sessions.
+- [ ] Enable the user to change hot key key, not only modifiers.
+- [ ] Add more hot keys (audio session control, reload, restart, show on current screen, PiP).
+    - [ ] Reload.
+    - [ ] Restart.
+    - [X] Show on current screen.
+    - [ ] Enable/disable PiP.
+    - [ ] Enable/disable overlay mode.
+- [ ] Translate all strings.
+    - [X] Settings page.
+    - [X] Main window menu.
+    - [ ] Audio profiles pages.
+    - [ ] Audio sessions page.
+    - [ ] Overlay page.
+- [ ] Change app logo to be the 'audio mixer' font icon.
+- [ ] Handle `ms-resources` when reading package information from app manifests.
+- [ ] Invalidate and release all audio objects when bug #2 occurs. This will allow the application to reload audio sessions without having to restart.
+
+*This update*
+- [X] Move audio controls to `AudioViewer`.
+- [X] Create UserProfile and store in it `AudioProfile` so that the audio settings are separated from other settings (such as window layout, overlay position and future stuff).
+- [ ] Implement `AudioProfileEditPage` exit confirmation dialog (changes check not done).
+- [X] Get settings from profiles:
+    - From audio profile.
+    - From user profile.
 
 
 

--- a/Croak/App.idl
+++ b/Croak/App.idl
@@ -1,6 +1,9 @@
-// Copyright (c) Microsoft Corporation and Contributors.
-// Licensed under the MIT License.
-
 namespace Croak
 {
+	enum AudioSessionLayout
+	{
+		Auto,
+		Horizontal,
+		Vertical
+	};
 }

--- a/Croak/AudioProfile.cpp
+++ b/Croak/AudioProfile.cpp
@@ -23,7 +23,7 @@ namespace winrt::Croak::implementation
         props.Values().Insert(L"KeepOnTop", IReference(keepOnTop));
         props.Values().Insert(L"ShowMenu", IReference(showMenu));
         props.Values().Insert(L"SystemVolume", IReference(systemVolume));
-        props.Values().Insert(L"Layout", IReference(layout));
+        props.Values().Insert(L"Layout", IReference(static_cast<uint32_t>(layout)));
 
         ApplicationDataContainer audioSettingsContainer = props.CreateContainer(L"AudioSessionsSettings", ApplicationDataCreateDisposition::Always);
         for (auto&& audioSessionSettings : audioSessionsSettings)
@@ -49,7 +49,8 @@ namespace winrt::Croak::implementation
         keepOnTop = unbox_value<bool>(container.Values().Lookup(L"KeepOnTop"));
         showMenu = unbox_value<bool>(container.Values().Lookup(L"ShowMenu"));
         systemVolume = unbox_value<float>(container.Values().Lookup(L"SystemVolume"));
-        layout = unbox_value<uint32_t>(container.Values().Lookup(L"Layout"));
+        uint32_t boxedLayout = unbox_value<uint32_t>(container.Values().Lookup(L"Layout"));
+        layout = static_cast<AudioSessionLayout>(boxedLayout);
 
         auto audioSessionsSettings = container.Containers().Lookup(L"AudioSessionsSettings").Values();
         auto sessionsIndexesContainer = container.Values().Lookup(L"SessionsIndexes").as<ApplicationDataCompositeValue>();

--- a/Croak/AudioProfile.h
+++ b/Croak/AudioProfile.h
@@ -19,6 +19,17 @@ namespace winrt::Croak::implementation
             e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"ProfileName"));
         }
 
+        inline winrt::Croak::AudioSessionSettings DefaultAudioEndpointSettings() const
+        {
+            return defaultAudioEndpointSettings;
+        }
+
+        inline void DefaultAudioEndpointSettings(const winrt::Croak::AudioSessionSettings& value)
+        {
+            defaultAudioEndpointSettings = value;
+            e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"DefaultAudioEndpointSettings"));
+        }
+
         inline winrt::Windows::Foundation::Collections::IVector<AudioSessionSettings> AudioSessionsSettings() const
         {
             return audioSessionsSettings;
@@ -50,17 +61,6 @@ namespace winrt::Croak::implementation
         {
             isDefaultProfile = value;
             e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"IsDefaultProfile"));
-        }
-
-        inline float SystemVolume() const
-        {
-            return systemVolume;
-        }
-
-        inline void SystemVolume(const float& value)
-        {
-            systemVolume = value;
-            e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"SystemVolume"));
         }
 
         inline bool DisableAnimations() const
@@ -96,12 +96,12 @@ namespace winrt::Croak::implementation
             e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"ShowMenu"));
         }
 
-        inline uint32_t Layout() const
+        inline winrt::Croak::AudioSessionLayout Layout() const
         {
             return layout;
         }
 
-        inline void Layout(const uint32_t& value)
+        inline void Layout(const winrt::Croak::AudioSessionLayout& value)
         {
             layout = value;
             e_propertyChanged(*this, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs(L"Layout"));
@@ -150,7 +150,8 @@ namespace winrt::Croak::implementation
         bool disableAnimations = false;
         bool keepOnTop = false;
         bool showMenu = false;
-        uint32_t layout = 0u;
+        winrt::Croak::AudioSessionLayout layout = winrt::Croak::AudioSessionLayout::Auto;
+        winrt::Croak::AudioSessionSettings defaultAudioEndpointSettings = nullptr;
 
         winrt::event<Microsoft::UI::Xaml::Data::PropertyChangedEventHandler> e_propertyChanged;
     };

--- a/Croak/AudioProfile.idl
+++ b/Croak/AudioProfile.idl
@@ -1,4 +1,5 @@
 import "AudioSessionSettings.idl";
+import "App.idl";
 
 namespace Croak
 {
@@ -9,16 +10,13 @@ namespace Croak
         AudioProfile();
 
         String ProfileName;
+        AudioSessionSettings DefaultAudioEndpointSettings;
         Windows.Foundation.Collections.IVector<AudioSessionSettings> AudioSessionsSettings;
         Windows.Foundation.Collections.IMap<String, UInt32> SessionsIndexes;
         Boolean IsDefaultProfile;
-        Single SystemVolume;
         Boolean DisableAnimations;
-        Boolean KeepOnTop;
+        AudioSessionLayout Layout;
         Boolean ShowMenu;
-        UInt32 Layout;
-        Boolean RestoreWindowState;
-        Windows.Graphics.RectInt32 WindowDisplayRect;
 
         void Restore(Windows.Storage.ApplicationDataContainer container);
         void Save(Windows.Storage.ApplicationDataContainer container);

--- a/Croak/AudioSessionView.xaml
+++ b/Croak/AudioSessionView.xaml
@@ -31,7 +31,7 @@
         CornerRadius="{x:Bind CornerRadius, Mode=OneWay}"
         BorderThickness="{x:Bind BorderThickness}"
         BorderBrush="{x:Bind BorderBrush}"
-        MaxHeight="290"
+        Height="290"
         MinWidth="80"
         SizeChanged="Grid_SizeChanged"
         PointerEntered="RootGrid_PointerEntered"
@@ -152,7 +152,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Grid.Row="1"
-                Translation="-5,0,0">
+                Translation="-6,0,0">
 
                 <Border.Clip>
                     <RectangleGeometry x:Name="BorderClippingLeft">
@@ -172,7 +172,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Grid.Row="1"
-                Translation="7,0,0">
+                Translation="6.5,0,0">
 
                 <Border.Clip>
                     <RectangleGeometry x:Name="BorderClippingRight">
@@ -218,7 +218,7 @@
                 VerticalAlignment="Stretch"
                 Grid.Row="1"
                 Margin="0,0,0,0"
-                Translation="1.5,0,0"
+                Translation="0,0,0"
                 ValueChanged="Slider_ValueChanged"/>
 
             <Button
@@ -331,7 +331,7 @@
                 Click="MuteToggleButton_Click">
 
                 <FontIcon 
-                    x:Name="VolumeFontIcon1" FontSize="{StaticResource FontIconHeight}" Glyph="{x:Bind VolumeGlyph, Mode=OneWay}"/>
+                    x:Name="VolumeFontIcon2" FontSize="{StaticResource FontIconHeight}" Glyph="{x:Bind VolumeGlyph, Mode=OneWay}"/>
             </Button>
 
             <Border 

--- a/Croak/AudioSessionView.xaml.cpp
+++ b/Croak/AudioSessionView.xaml.cpp
@@ -56,7 +56,7 @@ namespace winrt::Croak::implementation
 
     void AudioSessionView::Orientation(const Xaml::Orientation& value)
     {
-        isVertical = value == Xaml::Orientation::Vertical;
+        isVertical = (value == Xaml::Orientation::Vertical);
         Xaml::VisualStateManager::GoToState(*this, isVertical ? L"VerticalLayout" : L"HorizontalLayout", false);
     }
 
@@ -177,22 +177,25 @@ namespace winrt::Croak::implementation
                 active = true;
                 VolumeFontIcon().Foreground(Xaml::SolidColorBrush(Windows::UI::Colors::LimeGreen()));
                 VolumeFontIcon().Opacity(1);
+
+                VolumeFontIcon2().Foreground(Xaml::SolidColorBrush(Windows::UI::Colors::LimeGreen()));
+                VolumeFontIcon2().Opacity(1);
                 break;
 
             case AudioSessionState::Expired:
             case AudioSessionState::Inactive:
             default:
                 active = false;
-                /*VolumeFontIcon().Foreground(
-                     RootGrid().ActualTheme() == ElementTheme::Dark ?
-                        ::Media::SolidColorBrush(Windows::UI::Colors::WhiteSmoke()) :
-                        ::Media::SolidColorBrush(Windows::UI::Colors::DarkGray())
-                );*/
 
                 VolumeFontIcon().Foreground(
                     Xaml::Application::Current().Resources().Lookup(box_value(L"TextFillColorPrimaryBrush")).as<Xaml::Brush>()
                 );
                 VolumeFontIcon().Opacity(0.6);
+
+                VolumeFontIcon2().Foreground(
+                    Xaml::Application::Current().Resources().Lookup(box_value(L"TextFillColorPrimaryBrush")).as<Xaml::Brush>()
+                );
+                VolumeFontIcon2().Opacity(0.6);
                 break;
         }
     }
@@ -235,6 +238,8 @@ namespace winrt::Croak::implementation
         {
             Xaml::VisualStateManager::GoToState(*this, L"UsingLogo", true);
         }
+
+        Xaml::VisualStateManager::GoToState(*this, isVertical ? L"VerticalLayout" : L"HorizontalLayout", false);
     }
 
     void AudioSessionView::Slider_ValueChanged(IInspectable const&, Xaml::RangeBaseValueChangedEventArgs const& e)

--- a/Croak/AudioViewer.idl
+++ b/Croak/AudioViewer.idl
@@ -1,12 +1,27 @@
-// Copyright (c) Microsoft Corporation and Contributors.
-// Licensed under the MIT License.
+import "AudioSessionView.idl";
+import "App.idl";
+import "AudioProfile.idl";
+import "MessageBar.idl";
 
 namespace Croak
 {
     [default_interface]
-    runtimeclass AudioViewer : Microsoft.UI.Xaml.Controls.UserControl
+    runtimeclass AudioViewer : Microsoft.UI.Xaml.Controls.UserControl, Microsoft.UI.Xaml.Data.INotifyPropertyChanged
     {
         AudioViewer();
-        Int32 MyProperty;
+
+        IObservableVector<AudioSessionView> AudioSessions{ get; };
+        String DefaultAudioEndpointName{ get; };
+
+        void SetMessageBar(MessageBar messageBar);
+        void CloseAudioObjects();
+        void LoadAudioProfile(AudioProfile audioProfile);
+        void MuteEndpoint();
+        void PauseAnimations();
+        void SetAudioSessionLayout(AudioSessionLayout layout);
+        void StopAnimations();
+        void SwitchAudioState();
+        void ReloadAudioSessions();
+        void ShowHiddenAudioSessions();
     }
 }

--- a/Croak/AudioViewer.xaml
+++ b/Croak/AudioViewer.xaml
@@ -1,16 +1,247 @@
-﻿<!-- Copyright (c) Microsoft Corporation and Contributors. -->
-<!-- Licensed under the MIT License. -->
-
-<UserControl
+﻿<UserControl
     x:Class="Croak.AudioViewer"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Croak"
+    xmlns:c="using:Croak"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Background="Transparent"
+    Unloaded="UserControl_Unloaded">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid x:Name="RootGrid" SizeChanged="Grid_SizeChanged">
+        <Grid.Resources>
+            <Style x:Key="GridViewHorizontalLayout" TargetType="GridView">
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <ItemsWrapGrid 
+                                Orientation="Horizontal" 
+                                VerticalAlignment="Center" 
+                                HorizontalAlignment="Center"/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="GridViewVerticalLayout" TargetType="GridView">
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <ItemsStackPanel 
+                                HorizontalAlignment="Stretch" 
+                                VerticalAlignment="Center" 
+                                GroupPadding="5"/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Grid.Resources>
+        <Grid.ContextFlyout>
+            <TextCommandBarFlyout>
+                <AppBarButton Content="Show/hide" Icon="ViewAll" Click="AppBarButton_Click"/>
+            </TextCommandBarFlyout>
+        </Grid.ContextFlyout>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="1"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="5,0,5,3" ColumnSpacing="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="MuteToggleButtonColumn" Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition x:Name="SystemVolumeSliderTextColumn" Width="26"/>
+            </Grid.ColumnDefinitions>
+            <Grid.Resources>
+                <Storyboard x:Name="VolumeStoryboard">
+                    <DoubleAnimation 
+                        x:Name="LeftVolumeAnimation"
+                        Storyboard.TargetName="BorderLeftClippingCompositeTransform"
+                        Storyboard.TargetProperty="ScaleX"
+                        To="0"
+                        Duration="{StaticResource AudioMeterAnimationDuration}">
+
+                        <DoubleAnimation.EasingFunction>
+                            <QuadraticEase EasingMode="EaseOut"/>
+                        </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+
+                    <DoubleAnimation 
+                        x:Name="RightVolumeAnimation"
+                        Storyboard.TargetName="BorderRightClippingCompositeTransform"
+                        Storyboard.TargetProperty="ScaleX"
+                        To="0"
+                        Duration="{StaticResource AudioMeterAnimationDuration}">
+
+                        <DoubleAnimation.EasingFunction>
+                            <QuadraticEase EasingMode="EaseOut"/>
+                        </DoubleAnimation.EasingFunction>
+                    </DoubleAnimation>
+                </Storyboard>
+            </Grid.Resources>
+
+            <ToggleButton
+                x:Uid="MainWindowMuteToggleButton"
+                x:Name="MuteToggleButton"
+                Style="{StaticResource MuteToggleButtonStyle}"
+                Click="MuteToggleButton_Click">
+
+                <FontIcon x:Name="MuteToggleButtonFontIcon" Glyph="&#xe767;" FontSize="{StaticResource FontIconHeight}"/>
+            </ToggleButton>
+
+            <Border 
+                x:Name="SystemVolumeActivityBorderLeft"
+                Grid.Column="1"
+                Background="{StaticResource AudioMeterReversedBackground}"
+                Opacity="{ThemeResource PeakBorderOpacity}"
+                CornerRadius="5,5,0,0"
+                Height="7"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Stretch"
+                Translation="0,-5,0"
+                SizeChanged="SystemVolumeActivityBorder_SizeChanged">
+
+                <Border.Clip>
+                    <RectangleGeometry x:Name="SystemVolumeActivityBorderClippingLeft">
+                        <RectangleGeometry.Transform>
+                            <CompositeTransform x:Name="BorderLeftClippingCompositeTransform" ScaleX="0"/>
+                        </RectangleGeometry.Transform>
+                    </RectangleGeometry>
+                </Border.Clip>
+            </Border>
+
+            <Border 
+                x:Name="SystemVolumeActivityBorderRight"
+                Grid.Column="1"
+                Background="{StaticResource AudioMeterReversedBackground}"
+                Opacity="{ThemeResource PeakBorderOpacity}"
+                CornerRadius="0,0,5,5"
+                Height="7"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Stretch"
+                Translation="0,6,0">
+
+                <Border.Clip>
+                    <RectangleGeometry x:Name="SystemVolumeActivityBorderClippingRight">
+                        <RectangleGeometry.Transform>
+                            <CompositeTransform x:Name="BorderRightClippingCompositeTransform" ScaleX="0"/>
+                        </RectangleGeometry.Transform>
+                    </RectangleGeometry>
+                </Border.Clip>
+            </Border>
+
+            <Slider 
+                x:Uid="MainWindowSystemVolumeSlider"
+                x:Name="SystemVolumeSlider"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                ValueChanged="SystemVolumeSlider_ValueChanged">
+                <Slider.Transitions>
+                    <TransitionCollection>
+                        <RepositionThemeTransition IsStaggeringEnabled="False"/>
+                    </TransitionCollection>
+                </Slider.Transitions>
+            </Slider>
+
+            <c:NumberBlock
+                x:Name="SystemVolumeNumberBlock"
+                Grid.Column="2"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Center"/>
+        </Grid>
+
+        <Border
+            Grid.Row="1"
+            Background="{ThemeResource SubtleFillColorSecondaryBrush}"/>
+        
+        <Grid
+            x:Name="AppBarGrid"
+            Grid.Row="1"
+            ColumnSpacing="10"
+            Padding="5,4"
+            MaxWidth="250"
+            HorizontalAlignment="Stretch"
+            Visibility="Collapsed">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Grid.Resources>
+                <Style TargetType="Button" BasedOn="{StaticResource IconButtonStyle}"/>
+                <Style TargetType="FontIcon">
+                    <Setter Property="FontSize" Value="16"/>
+                </Style>
+            </Grid.Resources>
+
+            <Button>
+                <FontIcon Glyph="&#xe72c;"/>
+            </Button>
+
+            <Button Grid.Column="1">
+                <FontIcon Glyph="&#xe74f;"/>
+            </Button>
+
+            <Button Grid.Column="2">
+                <FontIcon Glyph="&#xe7b3;"/>
+            </Button>
+
+            <Button Grid.Column="3">
+                <FontIcon Glyph="&#xf4a5;"/>
+            </Button>
+        </Grid>
+
+        <Border Height="1" Background="{ThemeResource SystemControlForegroundBaseLowBrush}" Grid.Row="2"/>
+
+        <Grid x:Name="AudioSessionsGrid" Grid.Row="3" Margin="0,5,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <ScrollViewer 
+                x:Name="AudioSessionsScrollViewer"
+                Padding="3,0,0,0" 
+                Grid.Row="1"
+                HorizontalScrollBarVisibility="Disabled">
+
+                <Grid>
+                    <Canvas
+                        x:Name="IndicatorsCanvas"
+                        Background="Transparent"/>
+
+                    <GridView
+                        x:Name="AudioSessionsGridView"
+                        Style="{StaticResource GridViewHorizontalLayout}"
+                        ItemsSource="{x:Bind AudioSessions}"
+                        Margin="0,0,0,-7"
+                        SelectionMode="None"
+                        CanReorderItems="True"
+                        ReorderMode="Enabled"
+                        AllowDrop="True"
+                        Grid.Row="1"
+                        Loading="AudioSessionsPanel_Loading"
+                        Loaded="OnLoaded">
+                        <GridView.Resources>
+                            <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}">
+                                <Setter Property="AllowDrop" Value="False" />
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="VerticalAlignment" Value="Center"/>
+                            </Style>
+                        </GridView.Resources>
+                    </GridView>
+                </Grid>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/Croak/AudioViewer.xaml.cpp
+++ b/Croak/AudioViewer.xaml.cpp
@@ -1,17 +1,64 @@
-// Copyright (c) Microsoft Corporation and Contributors.
-// Licensed under the MIT License.
-
 #include "pch.h"
 #include "AudioViewer.xaml.h"
 #if __has_include("AudioViewer.g.cpp")
 #include "AudioViewer.g.cpp"
 #endif
 
-using namespace winrt;
-using namespace Microsoft::UI::Xaml;
+#include <regex>
+#include <string>
+#include "DebugOutput.h"
+#include "Hotkey.h"
+#include "HotkeyManager.h"
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+#define USE_TIMER
+//#define DEACTIVATE_TIMER
+#define ENABLE_HOTKEYS
+
+constexpr int VOLUME_DOWN = 1;
+constexpr int VOLUME_UP = 2;
+constexpr int VOLUME_UP_ALT = 3;
+constexpr int VOLUME_DOWN_ALT = 4;
+constexpr int MUTE_SYSTEM = 5;
+
+namespace CAudio = ::Croak::Audio;
+namespace Microsoft = winrt::Microsoft;
+namespace Windows = winrt::Windows;
+namespace Foundation = winrt::Windows::Foundation;
+namespace System = winrt::Windows::System;
+namespace Graphics = winrt::Windows::Graphics;
+namespace Collections = winrt::Windows::Foundation::Collections;
+namespace Power = Microsoft::Windows::System::Power;
+/**
+ * @brief Microsoft::UI, Microsoft::UI::Composition, Microsoft::UI::Composition::SystemBackdrops, Microsoft::UI::Windowing
+*/
+namespace UI
+{
+    using namespace winrt::Microsoft::UI;
+    using namespace winrt::Microsoft::UI::Windowing;
+}
+/**
+ * @brief Microsoft::UI::Xaml, Microsoft::UI::Xaml::Input, Microsoft::UI::Xaml::Controls, Microsoft::UI::Xaml::Media, Microsoft::UI::Xaml::Media::Imaging, Microsoft::UI::Xaml::Controls::Primitives
+*/
+namespace Xaml
+{
+    using namespace winrt::Microsoft::UI::Xaml;
+    using namespace winrt::Microsoft::UI::Xaml::Input;
+    using namespace winrt::Microsoft::UI::Xaml::Controls;
+    using namespace winrt::Microsoft::UI::Xaml::Media;
+    using namespace winrt::Microsoft::UI::Xaml::Media::Imaging;
+    using namespace winrt::Microsoft::UI::Xaml::Controls::Primitives;
+}
+/**
+ * @brief Windows::Storage, Windows::ApplicationModel, Windows::ApplicationModel::Core, Windows::ApplicationModel::Resources
+*/
+namespace Storage
+{
+    using namespace winrt::Windows::Storage;
+    using namespace winrt::Windows::ApplicationModel;
+    using namespace winrt::Windows::ApplicationModel::Core;
+    using namespace winrt::Windows::ApplicationModel::Resources;
+}
+
 
 namespace winrt::Croak::implementation
 {
@@ -20,18 +67,1283 @@ namespace winrt::Croak::implementation
         InitializeComponent();
     }
 
-    int32_t AudioViewer::MyProperty()
+    inline winrt::hstring AudioViewer::DefaultAudioEndpointName()
     {
-        throw hresult_not_implemented();
+        return defaultAudioEndpointName;
     }
 
-    void AudioViewer::MyProperty(int32_t /* value */)
+    inline winrt::event_token AudioViewer::PropertyChanged(const Microsoft::UI::Xaml::Data::PropertyChangedEventHandler& value)
     {
-        throw hresult_not_implemented();
+        return e_propertyChanged.add(value);
     }
 
-    void AudioViewer::myButton_Click(IInspectable const&, RoutedEventArgs const&)
+    inline void AudioViewer::PropertyChanged(const winrt::event_token& token)
     {
-        myButton().Content(box_value(L"Clicked"));
+        e_propertyChanged.remove(token);
+    }
+
+    void AudioViewer::SetMessageBar(const winrt::Croak::MessageBar& messageBar)
+    {
+        this->messageBar = messageBar;
+    }
+
+    void AudioViewer::CloseAudioObjects()
+    {
+        CleanUpResources(false);
+    }
+
+    void AudioViewer::MuteEndpoint()
+    {
+        mainAudioEndpoint->SetMute(!mainAudioEndpoint->Muted());
+        MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
+    }
+
+    void AudioViewer::LoadAudioProfile(const AudioProfile& audioProfile)
+    {
+        try
+        {
+#pragma region Basic profile stuff
+            // Set system volume.
+            mainAudioEndpoint->SetVolume(audioProfile.DefaultAudioEndpointSettings().AudioLevel());
+
+            if (audioProfile.DisableAnimations())
+            {
+                StopAnimations();
+            }
+
+            Croak::AudioSessionLayout windowLayout = audioProfile.Layout();
+            if (windowLayout != Croak::AudioSessionLayout::Auto)
+            {
+                SetAudioSessionLayout(windowLayout);
+            }
+#pragma endregion
+
+            AudioSessionsGridView().ItemsSource(nullptr);
+
+            // Set audio sessions volume.
+            std::unique_lock lock{ audioSessionsMutex }; // Taking the lock will also lock sessions from being added to the display.
+            auto audioSessionsSettings = audioProfile.AudioSessionsSettings();
+            for (auto&& audioSessionSettings : audioSessionsSettings)
+            {
+                for (std::pair<winrt::guid, CAudio::AudioSession*> iter : audioSessions)
+                {
+                    if (iter.second->Name() == audioSessionSettings.Name())
+                    {
+                        iter.second->SetVolume(audioSessionSettings.AudioLevel());
+                        iter.second->SetMute(audioSessionSettings.Muted());
+                    }
+                }
+            }
+
+            std::vector<AudioSessionView> uniqueSessions{};
+            // HACK: IVector<T>::GetMany does not seem to work. Manual copy.
+            for (uint32_t i = 0; i < audioSessionViews.Size(); i++)
+            {
+                uniqueSessions.push_back(audioSessionViews.GetAt(i));
+            }
+
+            auto indexes = audioProfile.SessionsIndexes();
+            auto&& views = std::vector<AudioSessionView>(indexes.Size(), nullptr);
+            for (size_t i = 0; i < uniqueSessions.size(); i++)
+            {
+                auto&& view = uniqueSessions[i];
+                auto opt = indexes.TryLookup(view.Header());
+                if (opt.has_value())
+                {
+                    size_t index = opt.value();
+                    if (index < views.size())
+                    {
+                        // The index might already be populated by the else if/else statements when the index is over the collection size.
+                        if (views[index] == nullptr)
+                        {
+                            views[index] = view;
+                        }
+                        else
+                        {
+                            views.push_back(views[index]);
+                            views[index] = view;
+                        }
+                    }
+                    else if (views[views.size() - 1] == nullptr) // Check if the last index of the collection is free.
+                    {
+                        views[views.size() - 1] = view;
+                    }
+                    else // The index is over the collection size and the last value of the collection is already populated.
+                    {
+                        views.push_back(view);
+                    }
+
+                    uniqueSessions[i] = nullptr; // Set to null to tell the session has been added.
+                }
+            }
+
+            // Add the sessions that were not in the profile.
+            // Try to add the session where there is still space. If not possible, append it.
+            bool hasTrailingNullptrs = true;
+            for (size_t i = 0; i < uniqueSessions.size(); i++)
+            {
+                if (uniqueSessions[i])
+                {
+                    int j = static_cast<int>(views.size()) - 1;
+                    for (; j >= 0; j--)
+                    {
+                        if (views[j] == nullptr)
+                        {
+                            views[j] = uniqueSessions[i];
+                            break;
+                        }
+                    }
+
+                    if (j < 0)
+                    {
+                        views.push_back(uniqueSessions[i]);
+                        hasTrailingNullptrs = false;
+                    }
+                }
+            }
+
+            if (hasTrailingNullptrs)
+            {
+                //HACK: Clear null values by passing another time through the view array.
+                size_t finalSize = views.size();
+                for (size_t i = 0; i < views.size(); i++)
+                {
+                    if (views[i] == nullptr)
+                    {
+                        size_t j = i + 1;
+                        while (j < views.size() && views[j] == nullptr)
+                        {
+                            j++;
+                        }
+
+                        if (j < views.size())
+                        {
+                            views[i] = std::move(views[j]);
+                        }
+                        else
+                        {
+                            finalSize--;
+                        }
+                    }
+                }
+                views.resize(finalSize);
+            }
+
+            audioSessionViews = winrt::multi_threaded_observable_vector<AudioSessionView>(std::move(views));
+
+            // HACK: Can we use INotifyPropertyChanged to raise that the vector has changed ?
+            AudioSessionsGridView().ItemsSource(audioSessionViews);
+            // I18N: Loaded profile [profile name]
+            EnqueueString(L"Loaded profile " + audioProfile.ProfileName());
+        }
+        catch (const hresult_error& error)
+        {
+            // I18N: Failed to load profile [profile name]
+            EnqueueString(L"Couldn't load profile " + audioProfile.ProfileName());
+            OutputDebugHString(error.message());
+        }
+        catch (const std::out_of_range& ex)
+        {
+            // TODO: Log exception to EventViewer to enable app analysis.
+            OutputDebugHString(to_hstring(ex.what()));
+            EnqueueString(L"Couldn't load profile " + audioProfile.ProfileName());
+        }
+    }
+
+    void AudioViewer::PauseAnimations()
+    {
+        if (audioSessionsPeakTimer.IsRunning())
+        {
+            audioSessionsPeakTimer.Stop();
+        }
+
+        if (mainAudioEndpointPeakTimer.IsRunning())
+        {
+            mainAudioEndpointPeakTimer.Stop();
+        }
+    }
+
+    void AudioViewer::SetAudioSessionLayout(const winrt::Croak::AudioSessionLayout& audioSessionLayout)
+    {
+        if (audioSessionLayout == AudioSessionLayout::Vertical)
+        {
+            // Vertical layout
+            AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
+            AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
+            AudioSessionsGridView().Style(
+                RootGrid().Resources().Lookup(box_value(L"GridViewVerticalLayout")).as<Xaml::Style>());
+        }
+        else if (audioSessionLayout == AudioSessionLayout::Horizontal)
+        {
+            // Horizontal layout
+            AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
+            AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
+
+            AudioSessionsGridView().Style(
+                RootGrid().Resources().Lookup(box_value(L"GridViewHorizontalLayout")).as<Xaml::Style>()
+            );
+        }
+        else
+        {
+            // Auto layout
+            AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
+            AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
+
+            AudioSessionsGridView().Style(
+                RootGrid().Resources().Lookup(box_value(L"GridViewHorizontalLayout")).as<Xaml::Style>()
+            );  
+        }
+
+        // Update audio sessions.
+        for (auto&& audioSession : audioSessionViews)
+        {
+            audioSession.Orientation(audioSessionLayout == AudioSessionLayout::Vertical ? Xaml::Orientation::Horizontal : Xaml::Orientation::Vertical);
+        }
+
+        layout = audioSessionLayout;
+    }
+
+    void AudioViewer::StopAnimations()
+    {
+        if (audioSessionsPeakTimer.IsRunning())
+        {
+            audioSessionsPeakTimer.Stop();
+        }
+        else
+        {
+            audioSessionsPeakTimer.Start();
+        }
+
+        if (mainAudioEndpointPeakTimer.IsRunning())
+        {
+            mainAudioEndpointPeakTimer.Stop();
+        }
+        else
+        {
+            mainAudioEndpointPeakTimer.Start();
+        }
+
+        for (auto&& view : audioSessionViews)
+        {
+            view.SetPeak(0, 0);
+        }
+
+        LeftVolumeAnimation().To(0.);
+        RightVolumeAnimation().To(0.);
+        VolumeStoryboard().Begin();
+    }
+
+    void AudioViewer::SwitchAudioState()
+    {
+        bool setMute = false;
+
+        uint32_t count = 0;
+        if (globalSessionAudioState == winrt::Croak::AudioSessionState::Unmuted)
+        {
+            for (auto&& view : audioSessionViews)
+            {
+                if (view.Muted())
+                {
+                    count++;
+                }
+            }
+
+            if (count != audioSessionViews.Size())
+            {
+                setMute = true;
+                globalSessionAudioState = AudioSessionState::Muted;
+            }
+        }
+        else if (globalSessionAudioState == winrt::Croak::AudioSessionState::Muted)
+        {
+            for (auto&& view : audioSessionViews)
+            {
+                if (!view.Muted())
+                {
+                    count++;
+                }
+            }
+
+            if (count == audioSessionViews.Size())
+            {
+                setMute = true;
+                globalSessionAudioState = AudioSessionState::Muted;
+            }
+            else
+            {
+                setMute = false;
+                globalSessionAudioState = AudioSessionState::Unmuted;
+            }
+        }
+
+        {
+            std::unique_lock lock{ audioSessionsMutex };
+            for (std::pair<guid, CAudio::AudioSession*> iter : audioSessions)
+            {
+                iter.second->Muted(setMute);
+            }
+        }
+
+        for (AudioSessionView view : audioSessionViews)
+        {
+            view.Muted(setMute);
+        }
+    }
+
+    void AudioViewer::ReloadAudioSessions()
+    {
+        Storage::ResourceLoader resLoader{};
+        // Stop peak timers to avoid race conditions for nullptrs.
+        if (audioSessionsPeakTimer.IsRunning())
+        {
+            audioSessionsPeakTimer.Stop();
+        }
+        /*if (mainAudioEndpointPeakTimer.IsRunning())
+        {
+            mainAudioEndpointPeakTimer.Stop();
+        }*/
+
+        audioSessionViews.Clear();
+        VolumeStoryboard().Stop();
+
+        // Unregister VolumeChanged event handler & unregister audio sessions from audio events and release com ptrs.
+        {
+            std::unique_lock lock{ audioSessionsMutex };
+            for (auto& pair : audioSessions)
+            {
+                CAudio::AudioSession* audioSession = pair.second;
+                audioSession->VolumeChanged(audioSessionVolumeChanged[pair.first]);
+                audioSession->StateChanged(audioSessionsStateChanged[pair.first]);
+                audioSession->Unregister();
+                audioSession->Release();
+            }
+            audioSessions.clear();
+            // The lock can be released since no interactions will be made with audioSessions && audioSessionViews
+        }
+
+        // Reload audio sessions.
+        try
+        {
+            auto audioSessionsVect = audioController->GetSessions();
+            for (size_t i = 0; i < audioSessionsVect->size(); i++)
+            {
+                audioSessions.insert({ guid(audioSessionsVect->at(i)->Id()), audioSessionsVect->at(i) });
+
+                AudioSessionView view = CreateRegisterView(audioSessionsVect->at(i));
+                if (view)
+                {
+                    audioSessionViews.Append(view);
+                }
+            }
+
+            if (!animationsDisabled)
+            {
+                audioSessionsPeakTimer.Start();
+            }
+
+            EnqueueString(resLoader.GetString(L"InfoAudioSessionsReloaded"));
+        }
+        catch (const winrt::hresult_error& err)
+        {
+            OutputDebugHString(L"Failed to reload audio sessions: " + err.message());
+        }
+    }
+
+    void AudioViewer::ShowHiddenAudioSessions()
+    {
+        static bool showingSessions = false;
+
+        /*
+        * - Show hidden sessions, enable item selection.
+        * - Selected audio sessions will be hidden the next time 'show hidden buttons' is clicked.
+        * - Unselected audio sessions will be kept the next time 'show hidden buttons' is clicked.
+        */
+        // TODO: How do I insert the new sessions: lookup in the profile (if loaded) or insert at the end to not disrupt the UX too much.
+        if (showingSessions)
+        {
+            AudioSessionsGridView().SelectionMode(Xaml::ListViewSelectionMode::None);
+            auto&& selectedItems = AudioSessionsGridView().SelectedItems();
+            auto ranges = AudioSessionsGridView().SelectedRanges();
+            for (auto&& range : ranges)
+            {
+                DebugLog(std::format("[{0:d}, {1:d}] length={2:d}", range.FirstIndex(), range.LastIndex(), range.Length()));
+            }
+        }
+        else
+        {
+            for (auto&& pair : audioSessions)
+            {
+                bool hidden = true;
+                for (auto&& view : audioSessionViews)
+                {
+                    if (pair.first == view.Id())
+                    {
+                        // Audio session is hidden
+                        hidden = false;
+                        break;
+                    }
+                }
+
+                if (hidden)
+                {
+                    CAudio::AudioSession* audioSession = pair.second;
+                    AudioSessionView view = CreateView(audioSession, false);
+                    if (view)
+                    {
+                        audioSessionViews.Append(view);
+                        view.IsEnabled(false);
+                    }
+                }
+            }
+
+            AudioSessionsGridView().SelectionMode(Xaml::ListViewSelectionMode::Multiple);
+        }
+
+        showingSessions = !showingSessions;
+    }
+
+
+    void AudioViewer::MuteToggleButton_Click(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
+    {
+        mainAudioEndpoint->SetMute(!mainAudioEndpoint->Muted());
+        MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
+    }
+
+    void AudioViewer::SystemVolumeActivityBorder_SizeChanged(Foundation::IInspectable const&, Xaml::SizeChangedEventArgs const&)
+    {
+        SystemVolumeActivityBorderClippingRight().Rect(
+            Foundation::Rect(0, 0, static_cast<float>(SystemVolumeActivityBorderRight().ActualWidth()), static_cast<float>(SystemVolumeActivityBorderRight().ActualHeight()))
+        );
+        SystemVolumeActivityBorderClippingLeft().Rect(
+            Foundation::Rect(0, 0, static_cast<float>(SystemVolumeActivityBorderLeft().ActualWidth()), static_cast<float>(SystemVolumeActivityBorderLeft().ActualHeight()))
+        );
+    }
+
+    void AudioViewer::SystemVolumeSlider_ValueChanged(Foundation::IInspectable const&, Xaml::RangeBaseValueChangedEventArgs const& e)
+    {
+        if (mainAudioEndpoint)
+        {
+            mainAudioEndpoint->Volume(static_cast<float>(e.NewValue() / 100.));
+        }
+
+        SystemVolumeNumberBlock().Double(e.NewValue());
+    }
+
+    void AudioViewer::AudioSessionsPanel_Loading(Xaml::FrameworkElement const&, Foundation::IInspectable const& args)
+    {
+        LoadContent();
+
+#ifdef ENABLE_HOTKEYS
+        LoadHotKeys();
+#endif // ENABLE_HOTKEYS
+    }
+
+    void AudioViewer::OnLoaded(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
+    {
+        atomicLoaded.exchange(true);
+
+        // Generate size changed event to get correct clipping rectangle size
+        SystemVolumeActivityBorder_SizeChanged(nullptr, nullptr);
+        Grid_SizeChanged(nullptr, nullptr);
+
+        audioSessionsPeakTimer.Start();
+        mainAudioEndpointPeakTimer.Start();
+
+        /*if ((!currentAudioProfile || !currentAudioProfile.DisableAnimations()) && 
+            (!audioSessionsPeakTimer.IsRunning() || !mainAudioEndpointPeakTimer.IsRunning()))
+        {
+            DEBUG_BREAK();
+        }*/
+
+        Power::PowerManager::UserPresenceStatusChanged([this](IInspectable, IInspectable)
+        {
+            auto userStatus = static_cast<int32_t>(Power::PowerManager::UserPresenceStatus());
+
+            switch (userStatus)
+            {
+                case static_cast<int32_t>(Power::UserPresenceStatus::Present):
+                {
+                    OutputDebugHString(L"User presence status changed: user present.");
+
+                    if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"PowerEfficiencyEnabled"), true))
+                    {
+                        DispatcherQueue().TryEnqueue([this]()
+                        {
+                            if (!mainAudioEndpointPeakTimer.IsRunning())
+                            {
+                                mainAudioEndpointPeakTimer.Start();
+                            }
+
+                            if (!audioSessionsPeakTimer.IsRunning())
+                            {
+                                audioSessionsPeakTimer.Start();
+                            }
+                        });
+                    }
+
+                    break;
+                }
+                case static_cast<int32_t>(Power::UserPresenceStatus::Absent):
+                case 2:
+                {
+                    OutputDebugHString(L"User presence status changed: user absent.");
+
+                    if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"PowerEfficiencyEnabled"), true))
+                    {
+                        DispatcherQueue().TryEnqueue([this]()
+                        {
+                            if (mainAudioEndpointPeakTimer.IsRunning())
+                            {
+                                mainAudioEndpointPeakTimer.Stop();
+                                LeftVolumeAnimation().To(0.);
+                                RightVolumeAnimation().To(0.);
+                                VolumeStoryboard().Begin();
+                            }
+
+                            if (audioSessionsPeakTimer.IsRunning())
+                            {
+                                audioSessionsPeakTimer.Stop();
+                                for (auto&& view : audioSessionViews)
+                                {
+                                    view.SetPeak(0, 0);
+                                }
+                            }
+                        });
+                    }
+                    break;
+                }
+            }
+        });
+    }
+
+    void AudioViewer::Grid_SizeChanged(Foundation::IInspectable const&, Xaml::SizeChangedEventArgs const&)
+    {
+        DrawSizeIndicators();
+    }
+
+    void AudioViewer::AudioSessionView_VolumeChanged(winrt::Croak::AudioSessionView const& sender, Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args)
+    {
+        if (audioSessions.find(sender.Id()) != audioSessions.end())
+        {
+            audioSessions[sender.Id()]->SetVolume(args.NewValue() / 100.f);
+        }
+    }
+
+    void AudioViewer::AudioSessionView_VolumeStateChanged(winrt::Croak::AudioSessionView const& sender, bool const& args)
+    {
+        //TODO: 
+    }
+
+    void AudioViewer::UserControl_Unloaded(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
+    {
+        //CleanUpResources(false);
+    }
+
+    void AudioViewer::AppBarButton_Click(Foundation::IInspectable const& sender, Xaml::RoutedEventArgs const& e)
+    {
+        ShowHiddenAudioSessions();
+    }
+
+
+    /**
+     * @brief Registers CAudio::AudioSession events and creates a view.
+     * @param audioSession 
+     * @return 
+    */
+    winrt::Croak::AudioSessionView AudioViewer::CreateRegisterView(CAudio::AudioSession* audioSession)
+    {
+        if (audioSession->Register())
+        {
+            audioSessionVolumeChanged.insert({ audioSession->Id(), audioSession->VolumeChanged({ this, &AudioViewer::AudioSession_VolumeChanged }) });
+            audioSessionsStateChanged.insert({ audioSession->Id(), audioSession->StateChanged({ this, &AudioViewer::AudioSession_StateChanged }) });
+        }
+        else
+        {
+            OutputDebugWString(L"Failed to register audio session '" + audioSession->Name() + L"'.");
+            EnqueueString(hstring(audioSession->Name() + L" notifications off"));
+        }
+
+        return CreateView(audioSession, true);
+    }
+
+    winrt::Croak::AudioSessionView AudioViewer::CreateView(CAudio::AudioSession* audioSession, bool checkDuplicates)
+    {
+        // Check for duplicates, multiple audio sessions might be grouped under one by the app/system owning the sessions.
+        if (checkDuplicates && audioSession->State() != ::AudioSessionState::AudioSessionStateActive)
+        {
+            std::unique_lock lock{ audioSessionsMutex };
+
+            uint8_t hitcount = 0u;
+            for (auto& iter : audioSessions)
+            {
+                if (iter.second->GroupingParam() == audioSession->GroupingParam())
+                {
+                    if (hitcount > 0)
+                    {
+                        return nullptr;
+                    }
+                    hitcount++;
+                }
+            }
+        }
+
+        AudioSessionView view = nullptr;
+        if (audioSession->IsSystemSoundSession())
+        {
+            view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
+
+            Xaml::FontIcon icon{};
+            icon.Glyph(L"\ue977");
+            // #5FDFFF
+            icon.Foreground(
+                Xaml::SolidColorBrush(Xaml::Application::Current().Resources().TryLookup(box_value(L"WindowsLogoColor")).as<Windows::UI::Color>())
+            );
+            Xaml::Viewbox iconViewbox{};
+            iconViewbox.HorizontalAlignment(Xaml::HorizontalAlignment::Stretch);
+            iconViewbox.VerticalAlignment(Xaml::VerticalAlignment::Stretch);
+            iconViewbox.Child(icon);
+            view.Logo().Content(iconViewbox);
+        }
+        else
+        {
+            if (!audioSession->ProcessInfo()->Manifest().Logo().empty())
+            {
+                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
+
+                Xaml::BitmapImage imageSource{};
+                imageSource.UriSource(Foundation::Uri(audioSession->ProcessInfo()->Manifest().Logo()));
+                Xaml::Image image{};
+                image.Source(imageSource);
+
+                view.Logo().Content(image);
+            }
+            else if (!audioSession->ProcessInfo()->ExecutablePath().empty())
+            {
+                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0, audioSession->ProcessInfo()->ExecutablePath());
+            }
+            else
+            {
+                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
+            }
+        }
+
+        view.Id(guid(audioSession->Id()));
+        view.Muted(audioSession->Muted());
+        view.SetState((AudioSessionState)audioSession->State());
+        view.Orientation(layout == AudioSessionLayout::Horizontal ? Xaml::Orientation::Horizontal : Xaml::Orientation::Vertical);
+
+        view.VolumeChanged({ this, &AudioViewer::AudioSessionView_VolumeChanged });
+        view.VolumeStateChanged({ this, &AudioViewer::AudioSessionView_VolumeStateChanged });
+        view.Hidden([this](AudioSessionView sender, auto)
+        {
+#ifdef DEBUG
+
+#else
+            for (auto const& view : audioSessionViews)
+            {
+                if (view.Id() == sender.Id())
+                {
+                    uint32_t indexOf = 0;
+                    if (audioSessionViews.IndexOf(view, indexOf))
+                    {
+                        audioSessionViews.RemoveAt(indexOf);
+                    }
+
+                    return;
+                }
+            }
+#endif // DEBUG
+
+        });
+
+        return view;
+    }
+
+    void AudioViewer::LoadContent()
+    {
+        Storage::ResourceLoader loader{};
+        GUID appID{};
+        if (SUCCEEDED(UuidCreate(&appID)))
+        {
+            try
+            {
+                // Create and setup audio interfaces.
+                audioController = new CAudio::AudioController(appID);
+
+                if (audioController->Register())
+                {
+                    audioController->SessionAdded({ this, &AudioViewer::AudioController_SessionAdded });
+                    audioController->EndpointChanged({ this, &AudioViewer::AudioController_EndpointChanged });
+                }
+                else
+                {
+                    EnqueueString(loader.GetString(L"ErrorAudioSessionsUnavailable"));
+                }
+
+                mainAudioEndpoint = audioController->GetMainAudioEndpoint();
+                DefaultAudioEndpointName(mainAudioEndpoint->Name());
+                if (mainAudioEndpoint->Register())
+                {
+                    mainAudioEndpointVolumeChangedToken = mainAudioEndpoint->VolumeChanged({ this, &AudioViewer::MainAudioEndpoint_VolumeChanged });
+                    mainAudioEndpointStateChangedToken = mainAudioEndpoint->StateChanged([this](IInspectable, bool muted)
+                    {
+                        DispatcherQueue().TryEnqueue([this, muted]()
+                        {
+                            MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
+                            MuteToggleButtonFontIcon().Glyph(muted ? L"\ue74f" : L"\ue767");
+                        });
+                    });
+                }
+
+                // TODO: Check code validity, no memory leaks, performance.
+                auto audioSessionsVector = std::unique_ptr<std::vector<CAudio::AudioSession*>>();
+                try
+                {
+                    audioSessionsVector = std::unique_ptr<std::vector<CAudio::AudioSession*>>(audioController->GetSessions());
+                    for (size_t i = 0; i < audioSessionsVector->size(); i++)
+                    {
+                        audioSessions.insert({ guid(audioSessionsVector->at(i)->Id()), audioSessionsVector->at(i) });
+
+                        // Check if the session is active, if not check if the user asked to show inactive sessions on startup.
+                        if (audioSessionsVector->at(i)->State() == ::AudioSessionState::AudioSessionStateActive ||
+                            unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"ShowInactiveSessionsOnStartup"), true))
+                        {
+                            if (AudioSessionView view = CreateRegisterView(audioSessionsVector->at(i)))
+                            {
+                                audioSessionViews.Append(view);
+                            }
+                        }
+                        else // Register to events since we are not adding/creating the view.
+                        {
+                            if (audioSessionsVector->at(i)->Register())
+                            {
+                                audioSessionVolumeChanged.insert({ audioSessionsVector->at(i)->Id(), audioSessionsVector->at(i)->VolumeChanged({ this, &AudioViewer::AudioSession_VolumeChanged }) });
+                                audioSessionsStateChanged.insert({ audioSessionsVector->at(i)->Id(), audioSessionsVector->at(i)->StateChanged({ this, &AudioViewer::AudioSession_StateChanged }) });
+                            }
+                            else
+                            {
+                                OutputDebugWString(L"Failed to register audio session '" + audioSessionsVector->at(i)->Name() + L"'. This session will never be shown.");
+                                EnqueueString(hstring(audioSessionsVector->at(i)->Name() + L" : notifications off"));
+                            }
+                        }
+                    }
+                }
+                catch (const hresult_error&)
+                {
+                    // Clean audioSessionsVector and throw the error back.
+                    if (audioSessionsVector.get())
+                    {
+                        for (size_t j = 0; j < audioSessionsVector->size(); j++)
+                        {
+                            audioSessionsVector->at(j)->Release();
+                        }
+
+                        auto vect = audioSessionsVector.release();
+                        delete vect;
+                    }
+                    throw;
+                }
+
+
+                // Create and setup peak meters timers
+                audioSessionsPeakTimer = DispatcherQueue().CreateTimer();
+                mainAudioEndpointPeakTimer = DispatcherQueue().CreateTimer();
+
+                audioSessionsPeakTimer.Interval(Foundation::TimeSpan(std::chrono::milliseconds(83)));
+                audioSessionsPeakTimer.Tick({ this, &AudioViewer::UpdatePeakMeters });
+                audioSessionsPeakTimer.Stop();
+
+                mainAudioEndpointPeakTimer.Interval(Foundation::TimeSpan(std::chrono::milliseconds(83)));
+                mainAudioEndpointPeakTimer.Tick([&](auto, auto)
+                {
+                    if (!atomicLoaded.load())
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        std::pair<float, float> peakValues = mainAudioEndpoint->GetPeaks();
+                        LeftVolumeAnimation().To(static_cast<double>(peakValues.first));
+                        RightVolumeAnimation().To(static_cast<double>(peakValues.second));
+                        VolumeStoryboard().Begin();
+                    }
+                    catch (const hresult_error&)
+                    {
+                        // TODO: Handle error.
+                    }
+                });
+
+                //MainEndpointNameTextBlock().Text(mainAudioEndpoint->Name());
+                SystemVolumeSlider().Value(static_cast<double>(mainAudioEndpoint->Volume()) * 100.);
+                MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
+                MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
+            }
+            catch (const hresult_error& ex)
+            {
+                EnqueueString(loader.GetString(L"ErrorFatalFailure"));
+                OutputDebugHString(ex.message());
+            }
+        }
+        else
+        {
+            EnqueueString(loader.GetString(L"ErrorFatalFailure"));
+        }
+    }
+
+    void AudioViewer::SaveAudioLevels()
+    {
+        Storage::ApplicationDataContainer audioLevels = Storage::ApplicationData::Current().LocalSettings().CreateContainer(
+            L"AudioLevels",
+            Storage::ApplicationData::Current().LocalSettings().Containers().HasKey(L"AudioLevels") ? Storage::ApplicationDataCreateDisposition::Existing : Storage::ApplicationDataCreateDisposition::Always
+        );
+
+        for (uint32_t i = 0; i < audioSessionViews.Size(); i++) // Only saving the visible audio sessions levels.
+        {
+            Storage::ApplicationDataCompositeValue compositeValue{};
+            compositeValue.Insert(L"Muted", box_value(audioSessionViews.GetAt(i).Muted()));
+            compositeValue.Insert(L"Level", box_value(audioSessionViews.GetAt(i).Volume()));
+            if (!audioSessionViews.GetAt(i).Header().empty())
+            {
+                audioLevels.Values().Insert(audioSessionViews.GetAt(i).Header(), compositeValue);
+            }
+        }
+    }
+
+    void AudioViewer::LoadHotKeys()
+    {
+        ::Croak::System::HotKeys::HotKeyManager& hotKeyManager = ::Croak::System::HotKeys::HotKeyManager::GetHotKeyManager();
+        hotKeyManager.HotKeyFired({ this, &AudioViewer::HotKeyFired });
+
+        try
+        {
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Windows | Windows::System::VirtualKeyModifiers::Control, VK_DOWN, true, VOLUME_DOWN);
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Windows | Windows::System::VirtualKeyModifiers::Control, VK_UP, true, VOLUME_UP);
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Menu, VK_UP, true, VOLUME_UP_ALT);
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Menu, VK_DOWN, true, VOLUME_DOWN_ALT);
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Shift, 'M', true, MUTE_SYSTEM);
+        }
+        catch (const std::invalid_argument& ex)
+        {
+            DebugLog(std::format("Could not register hot key.\n\t > {0}", ex.what()));
+            EnqueueMessage(box_value(L"Failed to enable some hot keys."));
+        }
+    }
+
+    void AudioViewer::LoadSettings()
+    {
+        //TODO: Load non audio related settings.
+    }
+
+    void AudioViewer::SaveSettings()
+    {
+        if (currentAudioProfile)
+        {
+            Collections::IPropertySet settings = Storage::ApplicationData::Current().LocalSettings().Values();
+            settings.Insert(L"AudioProfile", box_value(currentAudioProfile.ProfileName()));
+
+            if (unbox_value_or(settings.TryLookup(L"AllowChangesToLoadedProfile"), false))
+            {
+                //currentAudioProfile.SystemVolume(mainAudioEndpoint->Volume());
+                //currentAudioProfile.Layout(layout);
+                currentAudioProfile.ShowMenu(AppBarGrid().Visibility() == Xaml::Visibility::Visible);
+                currentAudioProfile.DisableAnimations(mainAudioEndpointPeakTimer.IsRunning());
+
+                std::unique_lock lock{ audioSessionsMutex };
+                for (std::pair<winrt::guid, CAudio::AudioSession*> iter : audioSessions)
+                {
+                    auto name = iter.second->Name();
+                    auto muted = iter.second->Muted();
+                    auto volume = iter.second->Volume();
+
+                    currentAudioProfile.AudioSessionsSettings().Append(AudioSessionSettings(name, muted, volume));
+                }
+
+                // If the user has a profile, the AudioProfile container has to exist, so no TryLookup and container creation.
+                currentAudioProfile.Save(Storage::ApplicationData::Current().LocalSettings().Containers().Lookup(L"AudioProfiles"));
+            }
+        }
+    }
+
+    void AudioViewer::CleanUpResources(const bool& forReload)
+    {
+        if (audioSessionsPeakTimer && audioSessionsPeakTimer.IsRunning())
+        {
+            audioSessionsPeakTimer.Stop();
+        }
+
+        if (!forReload && mainAudioEndpointPeakTimer && mainAudioEndpointPeakTimer.IsRunning())
+        {
+            mainAudioEndpointPeakTimer.Stop();
+        }
+
+        VolumeStoryboard().Stop();
+
+        // Unregister VolumeChanged event handler & unregister audio sessions from audio events and release com ptrs.
+        if (audioSessions.size() > 0)
+        {
+            std::unique_lock lock{ audioSessionsMutex };
+
+            for (auto& iter : audioSessions)
+            {
+                iter.second->VolumeChanged(audioSessionVolumeChanged[iter.first]);
+                iter.second->StateChanged(audioSessionsStateChanged[iter.first]);
+
+                assert(iter.second->Unregister());
+                assert(iter.second->Release() == 0);
+            }
+        }
+
+        // Clean up ComPtr/IUnknown objects
+        if (audioController)
+        {
+            if (mainAudioEndpoint)
+            {
+                mainAudioEndpoint->VolumeChanged(mainAudioEndpointVolumeChangedToken);
+                mainAudioEndpoint->Unregister();
+                mainAudioEndpoint->Release();
+            }
+
+            audioController->EndpointChanged(audioControllerEndpointChangedToken);
+            audioController->SessionAdded(audioControllerSessionAddedToken);
+
+            assert(audioController->Unregister());
+            assert(audioController->Release() == 0);
+        }
+
+        if (forReload)
+        {
+            audioSessionViews.Clear();
+        }
+        else
+        {
+            SaveAudioLevels();
+        }
+    }
+
+    void AudioViewer::InsertSessionAccordingToProfile(::Croak::Audio::AudioSession* audioSession)
+    {
+    }
+
+    void AudioViewer::DrawSizeIndicators()
+    {
+        if (layout != AudioSessionLayout::Vertical)
+        {
+            double gridHeight = AudioSessionsGrid().ActualHeight();
+            double gridWidth = AudioSessionsGrid().ActualWidth();
+
+            IndicatorsCanvas().Children().Clear();
+
+            int32_t position = 1;
+            const int32_t sessionHeight = 290 + 2;
+            while ((position * sessionHeight) < gridHeight)
+            {
+                winrt::Microsoft::UI::Xaml::Shapes::Rectangle rect{};
+                rect.Width(6);
+                rect.Height(1);
+                auto&& brush = Xaml::SolidColorBrush(UI::Colors::DimGray());
+                brush.Opacity(0.5);
+                rect.Fill(brush);
+
+                Xaml::Canvas::SetLeft(rect, 0);
+                Xaml::Canvas::SetTop(rect, position * sessionHeight);
+                IndicatorsCanvas().Children().Append(rect);
+
+                position++;
+            }
+
+            position = 1;
+            const int32_t sessionWidth = 80 + 3;
+            while ((position * sessionWidth) < gridWidth)
+            {
+                winrt::Microsoft::UI::Xaml::Shapes::Rectangle rect{};
+                rect.Width(1);
+                rect.Height(6);
+                auto&& brush = Xaml::SolidColorBrush(UI::Colors::DimGray());
+                brush.Opacity(0.5);
+                rect.Fill(brush);
+
+                Xaml::Canvas::SetLeft(rect, position * sessionWidth);
+                Xaml::Canvas::SetTop(rect, 0);
+                IndicatorsCanvas().Children().Append(rect);
+
+                position++;
+            }
+        }
+    }
+
+    void AudioViewer::HotKeyFired(const uint32_t& id, const Foundation::IInspectable&)
+    {
+        constexpr float stepping = 0.01f;
+        constexpr float largeStepping = 0.07f;
+        try
+        {
+            switch (id)
+            {
+                case VOLUME_DOWN:
+                {
+                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() - stepping > 0.f ? mainAudioEndpoint->Volume() - stepping : 0.f);
+                    break;
+                }
+                case VOLUME_UP:
+                {
+                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() + stepping < 1.f ? mainAudioEndpoint->Volume() + stepping : 1.f);
+                    break;
+                }
+                case VOLUME_UP_ALT:
+                {
+                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() + largeStepping < 1.f ? mainAudioEndpoint->Volume() + largeStepping : 1.f);
+                    break;
+                }
+                case VOLUME_DOWN_ALT:
+                {
+                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() - largeStepping > 0.f ? mainAudioEndpoint->Volume() - largeStepping : 0.f);
+                    break;
+                }
+                case MUTE_SYSTEM:
+                {
+                    mainAudioEndpoint->SetMute(!mainAudioEndpoint->Muted());
+
+                    DispatcherQueue().TryEnqueue([this]()
+                    {
+                        MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
+                        MuteToggleButton().IsChecked(Foundation::IReference(mainAudioEndpoint->Muted()));
+                    });
+                    break;
+                }
+                default:
+                {
+                    DebugLog(std::format("Hot key not recognized. Id: {0}", id));
+                }
+            }
+        }
+        catch (...)
+        {
+        }
+    }
+
+    void AudioViewer::UpdatePeakMeters(Foundation::IInspectable, Foundation::IInspectable)
+    {
+        if (!atomicLoaded.load() || audioSessions.size() == 0) return;
+
+        for (auto const& view : audioSessionViews)
+        {
+            auto&& pair = audioSessions.at(view.Id())->GetChannelsPeak();
+            view.SetPeak(pair.first, pair.second);
+        }
+    }
+
+    void AudioViewer::MainAudioEndpoint_VolumeChanged(Foundation::IInspectable, const float& newVolume)
+    {
+        if (!atomicLoaded.load()) return;
+
+        DispatcherQueue().TryEnqueue([this, newVolume]()
+        {
+            SystemVolumeSlider().Value(newVolume * 100.);
+        });
+    }
+
+    void AudioViewer::AudioSession_VolumeChanged(const winrt::guid& id, const float& newVolume)
+    {
+        if (!atomicLoaded.load()) return;
+
+        DispatcherQueue().TryEnqueue([this, id, newVolume]()
+        {
+            for (auto const& view : audioSessionViews)
+            {
+                if (view.Id() == id)
+                {
+                    view.Volume(static_cast<double>(newVolume) * 100.0);
+                }
+            }
+        });
+    }
+
+    void AudioViewer::AudioSession_StateChanged(const winrt::guid& id, const uint32_t& state)
+    {
+        if (!atomicLoaded.load()) return;
+
+        // Cast state to AudioSessionState, uint32_t is only used to cross ABI
+        AudioSessionState audioState = (AudioSessionState)state;
+        if (audioState == AudioSessionState::Expired || audioState == AudioSessionState::Active)
+        {
+            audioSessionsPeakTimer.Stop();
+
+            std::unique_lock lock{ audioSessionsMutex };
+            if (audioSessions.contains(id))
+            {
+                if (audioState == AudioSessionState::Active)
+                {
+                    // Check if the newly active session is added to the UI, if not I need to add it as it might 
+                    // have been skipped because of grouping params and the session being inactive at the time.
+                    bool added = false;
+                    for (auto const& view : audioSessionViews)
+                    {
+                        if (view.Id() == id)
+                        {
+                            added = true;
+                            break;
+                        }
+                    }
+
+                    if (!added)
+                    {
+                        lock.unlock();
+
+                        DispatcherQueue().TryEnqueue([this, id]()
+                        {
+                            std::unique_lock lock{ audioSessionsMutex };
+                            if (AudioSessionView view = CreateView(audioSessions.at(id), true))
+                            {
+                                audioSessionViews.InsertAt(0, view);
+                            }
+                        });
+
+                        // Return here since the code in DispatcherQueue().TryEnqueue([this, id, audioState]...) below relies on finding an AudioSessionView 
+                        // with the matching id. Or I found that the AudioSessionView with the given id does not exists.
+                        audioSessionsPeakTimer.Start();
+                        return;
+                    }
+                }
+                else
+                {
+                    // The audio session is expired 
+                    CAudio::AudioSession* session = audioSessions.at(id);
+                    session->VolumeChanged(audioSessionVolumeChanged[session->Id()]);
+                    session->StateChanged(audioSessionsStateChanged[session->Id()]);
+                    assert(session->Unregister());
+                    session->Release();
+
+                    audioSessions.erase(id);
+                }
+            }
+
+            audioSessionsPeakTimer.Start();
+        }
+
+        DispatcherQueue().TryEnqueue([this, id, audioState]()
+        {
+            for (auto const& view : audioSessionViews)
+            {
+                if (view.Id() == id)
+                {
+                    switch (audioState)
+                    {
+                        case AudioSessionState::Muted:
+                            view.Muted(true);
+                            break;
+
+                        case AudioSessionState::Unmuted:
+                            view.Muted(false);
+                            break;
+
+                        case AudioSessionState::Active:
+                        case AudioSessionState::Inactive:
+                            view.SetState(audioState);
+                            break;
+
+                        case AudioSessionState::Expired:
+                            uint32_t indexOf = 0;
+                            if (audioSessionViews.IndexOf(view, indexOf))
+                            {
+                                audioSessionViews.RemoveAt(indexOf);
+
+                                if (audioSessionViews.Size() == 0)
+                                {
+                                    EnqueueString(L"All sessions expired.");// I18N: Translate "All sessions expired"
+                                }
+                            }
+                            break;
+                    }
+                    return;
+                }
+            }
+        });
+    }
+
+    void AudioViewer::AudioController_SessionAdded(Foundation::IInspectable, Foundation::IInspectable)
+    {
+        // TODO: Reorder audio sessions according to the currently loaded audio profile (if any).
+        DispatcherQueue().TryEnqueue([this]()
+        {
+            audioSessionsPeakTimer.Stop();
+
+            while (CAudio::AudioSession* newSession = audioController->NewSession())
+            {
+                {
+                    std::unique_lock lock{ audioSessionsMutex };
+                    audioSessions.insert({ newSession->Id(), newSession });
+                }
+
+                if (AudioSessionView view = CreateRegisterView(newSession))
+                {
+                    // TODO: If a profile is loaded, find the right index for the audio session to be added to.
+                    audioSessionViews.InsertAt(0, view);
+                }
+            }
+
+            audioSessionsPeakTimer.Start();
+        });
+    }
+
+    void AudioViewer::AudioController_EndpointChanged(Foundation::IInspectable, Foundation::IInspectable)
+    {
+        // Stop animation while getting the new audio endpoint.
+        mainAudioEndpointPeakTimer.Stop();
+
+        mainAudioEndpoint->VolumeChanged(mainAudioEndpointVolumeChangedToken);
+        mainAudioEndpoint->StateChanged(mainAudioEndpointStateChangedToken);
+        mainAudioEndpoint->Unregister();
+        mainAudioEndpoint->Release();
+
+        mainAudioEndpoint = audioController->GetMainAudioEndpoint();
+        if (mainAudioEndpoint->Register())
+        {
+            // Register to events.
+            mainAudioEndpointVolumeChangedToken = mainAudioEndpoint->VolumeChanged({ this, &AudioViewer::MainAudioEndpoint_VolumeChanged });
+            mainAudioEndpointStateChangedToken = mainAudioEndpoint->StateChanged([this](IInspectable, bool muted)
+            {
+                DispatcherQueue().TryEnqueue([this, muted]()
+                {
+                    MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
+                    MuteToggleButtonFontIcon().Glyph(muted ? L"\ue74f" : L"\ue767");
+                });
+            });
+        }
+
+
+        DispatcherQueue().TryEnqueue([&]()
+        {
+            mainAudioEndpointPeakTimer.Start();
+                                                                     
+            SystemVolumeSlider().Value(static_cast<double>(mainAudioEndpoint->Volume()) * 100.);
+            MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
+
+            ReloadAudioSessions();
+
+            DefaultAudioEndpointName(mainAudioEndpoint->Name());
+        });
+    }
+
+    void AudioViewer::DefaultAudioEndpointName(const winrt::hstring& value)
+    {
+        defaultAudioEndpointName = value;
+        e_propertyChanged(*this, Xaml::Data::PropertyChangedEventArgs(L"DefaultAudioEndpointName"));
+    }
+
+    void AudioViewer::EnqueueString(const winrt::hstring& str)
+    {
+        if (messageBar)
+        {
+            messageBar.EnqueueString(str);
+        }
+    }
+
+    void AudioViewer::EnqueueMessage(const winrt::Windows::Foundation::IInspectable& inspectable)
+    {
+        if (messageBar)
+        {
+            messageBar.EnqueueMessage(inspectable);
+        }
     }
 }

--- a/Croak/AudioViewer.xaml.h
+++ b/Croak/AudioViewer.xaml.h
@@ -1,6 +1,3 @@
-// Copyright (c) Microsoft Corporation and Contributors.
-// Licensed under the MIT License.
-
 #pragma once
 
 #include "winrt/Microsoft.UI.Xaml.h"
@@ -8,16 +5,100 @@
 #include "winrt/Microsoft.UI.Xaml.Controls.Primitives.h"
 #include "AudioViewer.g.h"
 
+#include "AudioController.h"
+#include "AudioSession.h"
+#include "DefaultAudioEndpoint.h"
+#include "AudioSessionStates.h"
+
 namespace winrt::Croak::implementation
 {
     struct AudioViewer : AudioViewerT<AudioViewer>
     {
+    public:
         AudioViewer();
 
-        int32_t MyProperty();
-        void MyProperty(int32_t value);
+        // Properties
+        inline winrt::Windows::Foundation::Collections::IObservableVector<winrt::Croak::AudioSessionView> AudioSessions() const
+        {
+            return audioSessionViews;
+        }
+        inline winrt::hstring DefaultAudioEndpointName();
 
-        void myButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+        // Events
+        inline winrt::event_token PropertyChanged(const Microsoft::UI::Xaml::Data::PropertyChangedEventHandler& value);
+        inline void PropertyChanged(const winrt::event_token& token);
+
+        // Methods
+        inline void SetMessageBar(const winrt::Croak::MessageBar& messageBar);
+        void CloseAudioObjects();
+        void MuteEndpoint();
+        void LoadAudioProfile(const winrt::Croak::AudioProfile& audioProfile);
+        void PauseAnimations();
+        void SetAudioSessionLayout(const winrt::Croak::AudioSessionLayout& layout);
+        void StopAnimations();
+        void SwitchAudioState();
+        void ReloadAudioSessions();
+        void ShowHiddenAudioSessions();
+
+        // Event handlers
+        void OnLoaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        void MuteToggleButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        void SystemVolumeActivityBorder_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& e);
+        void SystemVolumeSlider_ValueChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
+        void AudioSessionsPanel_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
+        void Grid_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& e);
+        void AudioSessionView_VolumeChanged(winrt::Croak::AudioSessionView const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
+        void AudioSessionView_VolumeStateChanged(winrt::Croak::AudioSessionView const& sender, bool const& args);
+        void UserControl_Unloaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        void AppBarButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+
+    private:
+        winrt::hstring defaultAudioEndpointName = L"";
+        std::atomic_bool atomicLoaded{};
+        bool animationsDisabled = false;
+        winrt::Croak::AudioSessionLayout layout = winrt::Croak::AudioSessionLayout::Auto;
+        std::mutex audioSessionsMutex{};
+        std::mutex mainAudioEndpointMutex{};
+        ::Croak::Audio::DefaultAudioEndpoint* mainAudioEndpoint = nullptr;
+        ::Croak::Audio::AudioController* audioController = nullptr;
+        std::map<winrt::guid, ::Croak::Audio::AudioSession*> audioSessions{};
+        winrt::Croak::AudioProfile currentAudioProfile = nullptr;
+        winrt::Croak::MessageBar messageBar = nullptr;
+        winrt::event_token mainAudioEndpointVolumeChangedToken;
+        winrt::event_token mainAudioEndpointStateChangedToken;
+        winrt::event_token audioControllerSessionAddedToken;
+        winrt::event_token audioControllerEndpointChangedToken;
+        std::map<winrt::guid, winrt::event_token> audioSessionVolumeChanged{};
+        std::map<winrt::guid, winrt::event_token> audioSessionsStateChanged{};
+        winrt::Croak::AudioSessionState globalSessionAudioState = winrt::Croak::AudioSessionState::Unmuted;
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer audioSessionsPeakTimer = nullptr;
+        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer mainAudioEndpointPeakTimer = nullptr;
+        winrt::Windows::Foundation::Collections::IObservableVector<winrt::Croak::AudioSessionView> audioSessionViews
+        {
+            winrt::multi_threaded_observable_vector<winrt::Croak::AudioSessionView>()
+        };
+        event<Microsoft::UI::Xaml::Data::PropertyChangedEventHandler> e_propertyChanged;
+
+        winrt::Croak::AudioSessionView CreateRegisterView(::Croak::Audio::AudioSession* audioSession);
+        winrt::Croak::AudioSessionView CreateView(::Croak::Audio::AudioSession* audioSession, bool skipDuplicates);
+        void LoadContent();
+        void SaveAudioLevels();
+        void LoadHotKeys();
+        void LoadSettings();
+        void SaveSettings();
+        void CleanUpResources(const bool& forReload);
+        void InsertSessionAccordingToProfile(::Croak::Audio::AudioSession* audioSession);
+        void DrawSizeIndicators();
+        void HotKeyFired(const uint32_t& id, const Windows::Foundation::IInspectable& /*args*/);
+        void UpdatePeakMeters(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
+        void MainAudioEndpoint_VolumeChanged(winrt::Windows::Foundation::IInspectable /*sender*/, const float& newVolume);
+        void AudioSession_VolumeChanged(const winrt::guid& sender, const float& newVolume);
+        void AudioSession_StateChanged(const winrt::guid& sender, const uint32_t& state);
+        void AudioController_SessionAdded(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
+        void AudioController_EndpointChanged(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
+        void DefaultAudioEndpointName(const winrt::hstring& value);
+        void EnqueueString(const winrt::hstring& str);
+        void EnqueueMessage(const winrt::Windows::Foundation::IInspectable& inspectable);
     };
 }
 

--- a/Croak/Croak.vcxproj
+++ b/Croak/Croak.vcxproj
@@ -262,6 +262,10 @@
       <DependentUpon>SplashScreen.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="UserProfile.h">
+      <DependentUpon>UserProfile.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
@@ -417,6 +421,10 @@
       <DependentUpon>SplashScreen.xaml</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="UserProfile.cpp">
+      <DependentUpon>UserProfile.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl">
@@ -514,6 +522,9 @@
     <Midl Include="SplashScreen.idl">
       <DependentUpon>SplashScreen.xaml</DependentUpon>
       <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="UserProfile.idl">
+      <SubType>Designer</SubType>
     </Midl>
   </ItemGroup>
   <ItemGroup>

--- a/Croak/Croak.vcxproj.filters
+++ b/Croak/Croak.vcxproj.filters
@@ -4,16 +4,19 @@
     <Midl Include="App.idl" />
     <Midl Include="MainWindow.idl" />
     <Midl Include="HotkeyViewModel.idl">
-      <Filter>ViewModels</Filter>
+      <Filter>Models</Filter>
     </Midl>
     <Midl Include="NavigationBreadcrumbBarItem.idl">
-      <Filter>ViewModels</Filter>
+      <Filter>Models</Filter>
     </Midl>
     <Midl Include="AudioProfile.idl">
-      <Filter>ViewModels</Filter>
+      <Filter>Models</Filter>
     </Midl>
     <Midl Include="AudioSessionSettings.idl">
-      <Filter>ViewModels</Filter>
+      <Filter>Models</Filter>
+    </Midl>
+    <Midl Include="UserProfile.idl">
+      <Filter>Models</Filter>
     </Midl>
   </ItemGroup>
   <ItemGroup>
@@ -61,7 +64,7 @@
       <Filter>UI\Controls\CustomControls</Filter>
     </ClCompile>
     <ClCompile Include="HotKeyView.cpp">
-      <Filter>Workers\Audio</Filter>
+      <Filter>Workers\System\Hotkeys</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -105,7 +108,7 @@
     </ClInclude>
     <ClInclude Include="resource.h" />
     <ClInclude Include="HotKeyView.h">
-      <Filter>Workers\Audio</Filter>
+      <Filter>Workers\System\Hotkeys</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -294,14 +297,14 @@
     <Filter Include="Workers\System\Hotkeys">
       <UniqueIdentifier>{e6ef7de2-530d-4111-be69-9794b2e5af2c}</UniqueIdentifier>
     </Filter>
-    <Filter Include="ViewModels">
-      <UniqueIdentifier>{70ae19e6-1383-423a-ba7e-6aa7734a5229}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Assets\Translations">
       <UniqueIdentifier>{201a8cbe-645b-47e0-9ef4-bcd1fffbe551}</UniqueIdentifier>
     </Filter>
     <Filter Include="Assets\Images">
       <UniqueIdentifier>{998e7b27-b0e7-4ceb-9a82-a3af0b5c20fe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Models">
+      <UniqueIdentifier>{70ae19e6-1383-423a-ba7e-6aa7734a5229}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Croak/DebugOutput.h
+++ b/Croak/DebugOutput.h
@@ -59,3 +59,9 @@ inline void DebugLog(const std::string& text, const std::source_location& source
 
     OutputDebugStringA(out.c_str());
 }
+
+template<class TString>
+inline void DebugLog2(const TString& text, const std::source_location& sourceLocation = std::source_location::current())
+{
+
+}

--- a/Croak/Hotkey.cpp
+++ b/Croak/Hotkey.cpp
@@ -22,7 +22,6 @@ namespace Croak::System::HotKeys
         if (static_cast<uint32_t>(modifiers & VirtualKeyModifiers::Menu))
         {
             this->modifiers |= MOD_ALT;
-
         }
         if (static_cast<uint32_t>(modifiers & VirtualKeyModifiers::Shift))
         {
@@ -42,7 +41,7 @@ namespace Croak::System::HotKeys
             notificationThread->join(); // Wait for the thread to exit.
             delete notificationThread; // Free the memory.
 
-            DebugLog(std::format("Successfully free resources (key id: {0})", std::to_string(hotKeyId)));
+            DebugLog(std::format("Successfully freed resources (key id: {0})", std::to_string(hotKeyId)));
         }
     }
 
@@ -93,15 +92,12 @@ namespace Croak::System::HotKeys
                 }
                 else
                 {
-                    DebugLog(std::format("Hotkey (id: {0}) > GetMessage returned 0.", std::to_string(hotKeyId)));
                     break;
                 }
             }
 
             // Unregister the HotKey when exiting the thread.
             UnregisterHotKey(nullptr, hotKeyId);
-
-            DebugLog(std::format("Hotkey (id: {0}) > thread exiting.", std::to_string(hotKeyId)));
         }
     }
 }

--- a/Croak/IconButton.h
+++ b/Croak/IconButton.h
@@ -15,12 +15,12 @@ namespace winrt::Croak::implementation
         static Microsoft::UI::Xaml::DependencyProperty GlyphProperty()
         {
             return _glyphProperty;
-        };
+        }
 
         static Microsoft::UI::Xaml::DependencyProperty TextProperty()
         {
             return _textNameProperty;
-        };
+        }
 
         static Microsoft::UI::Xaml::DependencyProperty ContentProperty()
         {

--- a/Croak/IconToggleButton.h
+++ b/Croak/IconToggleButton.h
@@ -50,10 +50,10 @@ namespace winrt::Croak::implementation
         inline void Glyph(const winrt::hstring& value);
         inline bool IsOn();
         inline void IsOn(const bool& value);
-        inline winrt::hstring OnIcon();
-        inline void OnIcon(const winrt::hstring& value);
-        inline winrt::hstring OffIcon();
-        inline void OffIcon(const winrt::hstring& value);
+        inline winrt::Windows::Foundation::IInspectable OnIcon();
+        inline void OnIcon(const winrt::Windows::Foundation::IInspectable& value);
+        inline winrt::Windows::Foundation::IInspectable OffIcon();
+        inline void OffIcon(const winrt::Windows::Foundation::IInspectable& value);
         inline bool Compact();
         inline void Compact(const bool& value);
 

--- a/Croak/IconToggleButton.idl
+++ b/Croak/IconToggleButton.idl
@@ -16,8 +16,8 @@ namespace Croak
         IInspectable Content;
         String Glyph;
         Boolean IsOn;
-        String OnIcon;
-        String OffIcon;
+        IInspectable OnIcon;
+        IInspectable OffIcon;
         Boolean Compact;
 
         event Windows.Foundation.TypedEventHandler<IconToggleButton, Microsoft.UI.Xaml.RoutedEventArgs> Click;

--- a/Croak/MainWindow.idl
+++ b/Croak/MainWindow.idl
@@ -1,4 +1,4 @@
-import "AudioSessionView.idl";
+import "AudioViewer.idl";
 
 namespace Croak
 {
@@ -9,7 +9,7 @@ namespace Croak
 
         static MainWindow Current{ get; };
 
-        IObservableVector<AudioSessionView> AudioSessions{ get; };
         Windows.Graphics.RectInt32 DisplayRect{ get; };
+        AudioViewer AudioViewer{ get; };
     }
 }

--- a/Croak/MainWindow.xaml
+++ b/Croak/MainWindow.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-    xmlns:s="using:Croak"
+    xmlns:c="using:Croak"
     mc:Ignorable="d"
     Activated="Window_Activated">
 
@@ -226,11 +226,11 @@
                                         Orientation="Vertical" 
                                         Spacing="4" >
                                         <StackPanel.Resources>
-                                            <Style TargetType="s:IconButton">
+                                            <Style TargetType="c:IconButton">
                                                 <Setter Property="Padding" Value="10,7" />
                                                 <Setter Property="Margin" Value="1,0" />
                                             </Style>
-                                            <Style TargetType="s:IconToggleButton">
+                                            <Style TargetType="c:IconToggleButton">
                                                 <Setter Property="Padding" Value="10,7" />
                                                 <Setter Property="Margin" Value="1,0" />
                                             </Style>
@@ -239,8 +239,8 @@
                                             <RepositionThemeTransition/>
                                         </StackPanel.Transitions>
 
-                                        <s:IconButton Glyph="&#xe748;" Click="OpenProfilesIconButton_Click">
-                                            <s:IconButton.Content>
+                                        <c:IconButton Glyph="&#xe748;" Click="OpenProfilesIconButton_Click">
+                                            <c:IconButton.Content>
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="*"/>
@@ -250,51 +250,55 @@
                                                     <TextBlock x:Uid="MainWindowOpenProfilesText" TextWrapping="Wrap" />
                                                     <FontIcon Glyph="&#xe76c;" Grid.Column="1" FontSize="14" Opacity="0.6" />
                                                 </Grid>
-                                            </s:IconButton.Content>
-                                        </s:IconButton>
+                                            </c:IconButton.Content>
+                                        </c:IconButton>
 
                                         <Border Style="{StaticResource BorderFlyoutSeparatorStyle}" />
 
-                                        <s:IconToggleButton 
+                                        <c:IconToggleButton 
                                             x:Uid="MainWindowDisableAnimationsButton"
                                             x:Name="DisableAnimationsIconToggleButton"
-                                            Glyph="&#xf4a5;" 
-                                            Click="DisableAnimationsIconButton_Click" />
+                                            OnIcon="&#xf4a5;"
+                                            Click="DisableAnimationsIconButton_Click">
+                                            <c:IconToggleButton.OffIcon>
+                                                <FontIcon Glyph="&#xf4a5;" FontSize="14" Foreground="{ThemeResource SystemAccentColor}"/>
+                                            </c:IconToggleButton.OffIcon>
+                                        </c:IconToggleButton>
 
-                                        <s:IconToggleButton 
+                                        <c:IconToggleButton 
                                             x:Uid="MainWindowDisableHotKeysButton"
                                             Glyph="&#xe765;" 
                                             Click="DisableHotKeysIconButton_Click"/>
 
-                                        <s:IconToggleButton 
+                                        <c:IconToggleButton 
                                             x:Uid="MainWindowShowAppBarButton"
                                             x:Name="ShowAppBarIconToggleButton"
                                             Glyph="&#xede3;" 
                                             Click="ShowAppBarIconButton_Click"/>
 
-                                        <s:IconButton 
+                                        <c:IconButton 
                                             x:Uid="MainWindowReloadSessionsButton"
                                             Text="Reload audio sessions" 
                                             Glyph="&#xe895;" 
                                             Click="ReloadSessionsIconButton_Click">
-                                            <s:IconButton.KeyboardAccelerators>
+                                            <c:IconButton.KeyboardAccelerators>
                                                 <KeyboardAccelerator Modifiers="Control,Shift" Key="R" />
-                                            </s:IconButton.KeyboardAccelerators>
-                                        </s:IconButton>
+                                            </c:IconButton.KeyboardAccelerators>
+                                        </c:IconButton>
 
-                                        <s:IconButton 
+                                        <c:IconButton 
                                             x:Uid="MainWindowRestartApplicationButton"
                                             Text="Restart application" 
                                             Glyph="&#xe72c;" 
                                             Click="RestartIconButton_Click">
-                                            <s:IconButton.KeyboardAccelerators>
+                                            <c:IconButton.KeyboardAccelerators>
                                                 <KeyboardAccelerator Modifiers="Control" Key="R" />
-                                            </s:IconButton.KeyboardAccelerators>
-                                        </s:IconButton>
+                                            </c:IconButton.KeyboardAccelerators>
+                                        </c:IconButton>
 
                                         <Border Style="{StaticResource BorderFlyoutSeparatorStyle}" />
 
-                                        <s:IconButton x:Uid="MainWindowSettingsButton" Text="Settings" Glyph="&#xe713;" Click="SettingsIconButton_Click"/>
+                                        <c:IconButton x:Uid="MainWindowSettingsButton" Text="Settings" Glyph="&#xe713;" Click="SettingsIconButton_Click"/>
                                     </StackPanel>
 
                                     <Grid x:Name="ProfilesGrid" Visibility="Collapsed">
@@ -341,7 +345,8 @@
                 </Button>
 
                 <TextBlock 
-                    x:Name="MainEndpointNameTextBlock" 
+                    x:Name="MainEndpointNameTextBlock"
+                    Text="{x:Bind AudioViewer.DefaultAudioEndpointName, Mode=OneWay}"
                     Grid.Column="2"
                     Style="{StaticResource CaptionTextBlockStyle}"
                     TextWrapping="Wrap"
@@ -356,225 +361,23 @@
                 </TextBlock>
             </Grid>
 
-            <Grid x:Name="ContentGrid" Grid.Row="1" Margin="0,-3,0,0" Visibility="Collapsed">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="1"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+            <c:AudioViewer x:Name="AudioViewer" Grid.Row="1" Margin="0,-3,0,0" Visibility="Collapsed"/>
 
-                <Grid Grid.Row="0" Margin="5,0,5,3" ColumnSpacing="3">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition x:Name="MuteToggleButtonColumn" Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition x:Name="SystemVolumeSliderTextColumn" Width="26"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.Resources>
-                        <Storyboard x:Name="VolumeStoryboard">
-                            <DoubleAnimation 
-                                x:Name="LeftVolumeAnimation"
-                                Storyboard.TargetName="BorderLeftClippingCompositeTransform"
-                                Storyboard.TargetProperty="ScaleX"
-                                To="0"
-                                Duration="{StaticResource AudioMeterAnimationDuration}">
-
-                                <DoubleAnimation.EasingFunction>
-                                    <QuadraticEase EasingMode="EaseOut"/>
-                                </DoubleAnimation.EasingFunction>
-                            </DoubleAnimation>
-
-                            <DoubleAnimation 
-                                x:Name="RightVolumeAnimation"
-                                Storyboard.TargetName="BorderRightClippingCompositeTransform"
-                                Storyboard.TargetProperty="ScaleX"
-                                To="0"
-                                Duration="{StaticResource AudioMeterAnimationDuration}">
-
-                                <DoubleAnimation.EasingFunction>
-                                    <QuadraticEase EasingMode="EaseOut"/>
-                                </DoubleAnimation.EasingFunction>
-                            </DoubleAnimation>
-                        </Storyboard>
-                    </Grid.Resources>
-
-                    <ToggleButton
-                        x:Uid="MainWindowMuteToggleButton"
-                        x:Name="MuteToggleButton"
-                        Style="{StaticResource MuteToggleButtonStyle}"
-                        Click="MuteToggleButton_Click">
-
-                        <FontIcon x:Name="MuteToggleButtonFontIcon" Glyph="&#xe767;" FontSize="{StaticResource FontIconHeight}"/>
-                    </ToggleButton>
-
-                    <Border 
-                        x:Name="SystemVolumeActivityBorderLeft"
-                        Grid.Column="1"
-                        Background="{StaticResource AudioMeterReversedBackground}"
-                        Opacity="{ThemeResource PeakBorderOpacity}"
-                        CornerRadius="5,5,0,0"
-                        Height="7"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Stretch"
-                        Translation="0,-5,0"
-                        SizeChanged="SystemVolumeActivityBorder_SizeChanged">
-
-                        <Border.Clip>
-                            <RectangleGeometry x:Name="SystemVolumeActivityBorderClippingLeft">
-                                <RectangleGeometry.Transform>
-                                    <CompositeTransform x:Name="BorderLeftClippingCompositeTransform" ScaleX="0"/>
-                                </RectangleGeometry.Transform>
-                            </RectangleGeometry>
-                        </Border.Clip>
-                    </Border>
-
-                    <Border 
-                        x:Name="SystemVolumeActivityBorderRight"
-                        Grid.Column="1"
-                        Background="{StaticResource AudioMeterReversedBackground}"
-                        Opacity="{ThemeResource PeakBorderOpacity}"
-                        CornerRadius="0,0,5,5"
-                        Height="7"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Stretch"
-                        Translation="0,6,0">
-
-                        <Border.Clip>
-                            <RectangleGeometry x:Name="SystemVolumeActivityBorderClippingRight">
-                                <RectangleGeometry.Transform>
-                                    <CompositeTransform x:Name="BorderRightClippingCompositeTransform" ScaleX="0"/>
-                                </RectangleGeometry.Transform>
-                            </RectangleGeometry>
-                        </Border.Clip>
-                    </Border>
-
-                    <Slider 
-                        x:Uid="MainWindowSystemVolumeSlider"
-                        x:Name="SystemVolumeSlider"
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        ValueChanged="SystemVolumeSlider_ValueChanged">
-                        <Slider.Transitions>
-                            <TransitionCollection>
-                                <RepositionThemeTransition IsStaggeringEnabled="False"/>
-                            </TransitionCollection>
-                        </Slider.Transitions>
-                    </Slider>
-
-                    <s:NumberBlock
-                        x:Name="SystemVolumeNumberBlock"
-                        Grid.Column="2"
-                        VerticalAlignment="Center"
-                        HorizontalAlignment="Center"/>
-                </Grid>
-
-                <Border
-                    Grid.Row="1"
-                    Background="{ThemeResource SubtleFillColorSecondaryBrush}"/>
-                <Grid
-                    x:Name="AppBarGrid"
-                    Grid.Row="1"
-                    ColumnSpacing="10"
-                    Padding="5,4"
-                    MaxWidth="250"
-                    HorizontalAlignment="Stretch"
-                    Visibility="Collapsed">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                        <ColumnDefinition/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.Resources>
-                        <Style TargetType="Button" BasedOn="{StaticResource IconButtonStyle}"/>
-                        <Style TargetType="FontIcon">
-                            <Setter Property="FontSize" Value="16"/>
-                        </Style>
-                    </Grid.Resources>
-
-                    <Button>
-                        <FontIcon Glyph="&#xe72c;"/>
-                    </Button>
-
-                    <Button Grid.Column="1">
-                        <FontIcon Glyph="&#xe74f;"/>
-                    </Button>
-
-                    <Button Grid.Column="2">
-                        <FontIcon Glyph="&#xe7b3;"/>
-                    </Button>
-
-                    <Button Grid.Column="3">
-                        <FontIcon Glyph="&#xf4a5;"/>
-                    </Button>
-                </Grid>
-
-                <Border Height="1" Background="{ThemeResource SystemControlForegroundBaseLowBrush}" Grid.Row="2"/>
-
-                <Grid Grid.Row="3" Margin="0,5,0,0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-
-                    <ScrollViewer 
-                        x:Name="AudioSessionsScrollViewer"
-                        Padding="3,0,0,0" 
-                        Grid.Row="1"
-                        HorizontalScrollBarVisibility="Disabled">
-
-                        <Grid>
-                            <Canvas
-                                x:Name="RootCanvas"
-                                Background="Transparent"/>
-                            
-                            <GridView
-                                x:Name="AudioSessionsPanel"
-                                Style="{StaticResource GridViewHorizontalLayout}"
-                                ItemsSource="{x:Bind AudioSessions}"
-                                Margin="0,0,0,-7"
-                                SelectionMode="None"
-                                CanReorderItems="True"
-                                ReorderMode="Enabled"
-                                AllowDrop="True"
-                                Grid.Row="1"
-                                Loading="AudioSessionsPanel_Loading"
-                                Loaded="OnLoaded">
-                                <GridView.Resources>
-                                    <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}">
-                                        <Setter Property="AllowDrop" Value="False" />
-                                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                                        <Setter Property="VerticalAlignment" Value="Stretch"/>
-                                    </Style>
-                                </GridView.Resources>
-                            </GridView>
-                        </Grid>
-                    </ScrollViewer>
-
-                    <s:MessageBar
-                        x:Name="WindowMessageBar"
-                        Grid.Row="0" 
-                        VerticalAlignment="Top"
-                        Visibility="Collapsed"
-                        Margin="5,3"/>
-                </Grid>
-            </Grid>
-
-            <s:SplashScreen
+            <c:SplashScreen
                 x:Name="WindowSplashScreen"
                 Grid.Row="2"
                 OnScreenTimeSpan="0:0:01"
                 Dismissed="SplashScreen_Dismissed">
-                <s:SplashScreen.Background>
+                <c:SplashScreen.Background>
                     <LinearGradientBrush StartPoint="0,0" EndPoint="0,1" Opacity="0.6" ColorInterpolationMode="SRgbLinearInterpolation" MappingMode="RelativeToBoundingBox" SpreadMethod="Pad">
                         <LinearGradientBrush.GradientStops>
                             <GradientStop Color="{ThemeResource SolidBackgroundFillColorSecondary}" Offset="0.2"/>
                             <GradientStop Color="{ThemeResource SystemAccentColorDark1}" Offset="2.5"/>
                         </LinearGradientBrush.GradientStops>
                     </LinearGradientBrush>
-                </s:SplashScreen.Background>
+                </c:SplashScreen.Background>
 
-                <s:SplashScreen.TopContent>
+                <c:SplashScreen.TopContent>
                     <Grid VerticalAlignment="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -584,18 +387,30 @@
                         <TextBlock Text="Croak" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center"/>
                         <TextBlock x:Name="ApplicationVersionTextBlock" Style="{StaticResource TitleTextBlockStyle}" Grid.Column="1" VerticalAlignment="Center"/>
                     </Grid>
-                </s:SplashScreen.TopContent>
+                </c:SplashScreen.TopContent>
 
-                <s:SplashScreen.MainContent>
+                <c:SplashScreen.MainContent>
                     <Viewbox MaxHeight="80" MaxWidth="80">
                         <FontIcon Glyph="&#xf4c3;"/>
                     </Viewbox>
-                </s:SplashScreen.MainContent>
+                </c:SplashScreen.MainContent>
 
-                <s:SplashScreen.BottomContent>
+                <c:SplashScreen.BottomContent>
                     <TextBlock Text="by psykomicron 🐢" FontStretch="UltraExpanded" Opacity="0.6"/>
-                </s:SplashScreen.BottomContent>
-            </s:SplashScreen>
+                </c:SplashScreen.BottomContent>
+            </c:SplashScreen>
+
+            <c:MessageBar
+                x:Name="WindowMessageBar"
+                Grid.Row="1" 
+                Padding="3,5"
+                Margin="0,0,0,5"
+                CornerRadius="0"
+                MinWidth="80"
+                Background="{ThemeResource SystemAccentColorDark2}"
+                VerticalAlignment="Bottom"
+                HorizontalAlignment="Center"
+                Visibility="Collapsed"/>
 
             <TeachingTip
                 Name="SettingsButtonTeachingTip"

--- a/Croak/MainWindow.xaml.cpp
+++ b/Croak/MainWindow.xaml.cpp
@@ -4,24 +4,16 @@
 #include "MainWindow.g.cpp"
 #endif
 
-#include <ppl.h>
-#include <ppltasks.h>
 #include "SecondWindow.xaml.h"
 #include "IconHelper.h"
 #include "HotKey.h"
 #include "HotKeyManager.h"
 #include "DebugOutput.h"
 
-#define USE_TIMER 1
-#define DEACTIVATE_TIMER 0
-#define ENABLE_HOTKEYS 1
+#define ENABLE_HOTKEYS
 
-constexpr int VOLUME_DOWN = 1;
-constexpr int VOLUME_UP = 2;
-constexpr int VOLUME_UP_ALT = 3;
-constexpr int VOLUME_DOWN_ALT = 4;
-constexpr int MUTE_SYSTEM = 5;
 constexpr int MOVE_WINDOW = 6;
+constexpr int MOVE_WINDOW_ALT = 7;
 
 namespace CAudio = ::Croak::Audio;
 namespace Microsoft = winrt::Microsoft;
@@ -63,7 +55,6 @@ namespace Storage
     using namespace winrt::Windows::Storage;
     using namespace winrt::Windows::ApplicationModel;
     using namespace winrt::Windows::ApplicationModel::Core;
-    using namespace winrt::Windows::ApplicationModel::Resources;
 }
 
 
@@ -76,7 +67,9 @@ namespace winrt::Croak::implementation
         singleton = *this;
 
         InitializeComponent();
+        AudioViewer().SetMessageBar(WindowMessageBar());
         InitializeWindow();
+
         SettingsButtonTeachingTip().Target(SettingsButton());
 
         if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"ShowSplashScreen"), true))
@@ -91,7 +84,7 @@ namespace winrt::Croak::implementation
         else
         {
             WindowSplashScreen().Visibility(Xaml::Visibility::Collapsed);
-            ContentGrid().Visibility(Xaml::Visibility::Visible);
+            AudioViewer().Visibility(Xaml::Visibility::Visible);
         }
 
         // If the application has been restarted by the user, or started with arguments.
@@ -108,26 +101,6 @@ namespace winrt::Croak::implementation
     {
         loaded = true;
 
-#if USE_TIMER
-        if (!DisableAnimationsIconToggleButton().IsOn())
-        {
-            if (mainAudioEndpoint)
-            {
-                mainAudioEndpointPeakTimer.Start();
-                VolumeStoryboard().Begin();
-            }
-
-            if (audioSessions.size() > 0)
-            {
-                audioSessionsPeakTimer.Start();
-            }
-        }
-#endif // USE_TIMER
-
-        // Generate size changed event to get correct clipping rectangle size
-        SystemVolumeActivityBorder_SizeChanged(nullptr, nullptr);
-        Grid_SizeChanged(nullptr, nullptr);
-
         // Teaching tips
         Storage::ApplicationDataContainer teachingTips = Storage::ApplicationData::Current().LocalSettings().Containers().TryLookup(L"TeachingTips");
         if (!teachingTips)
@@ -137,20 +110,6 @@ namespace winrt::Croak::implementation
         if (!teachingTips.Values().HasKey(L"ShowSettingsTeachingTip"))
         {
             teachingTips.Values().Insert(L"ShowSettingsTeachingTip", Foundation::IReference(false));
-        }
-
-        switch (layout)
-        {
-            case 1:
-                HorizontalViewMenuFlyoutItem_Click(nullptr, nullptr);
-                break;
-            case 2:
-                VerticalViewMenuFlyoutItem_Click(nullptr, nullptr);
-                break;
-            case 0:
-            default:
-                AutoViewMenuFlyoutItem_Click(nullptr, nullptr);
-                break;
         }
 
         using namespace Microsoft::Windows::System::Power;
@@ -170,23 +129,7 @@ namespace winrt::Croak::implementation
                         if (!DisableAnimationsIconToggleButton().IsOn())
                         {
                             OutputDebugHString(L"Battery saver enabled, disabling animations.");
-
-                            if (mainAudioEndpointPeakTimer.IsRunning())
-                            {
-                                mainAudioEndpointPeakTimer.Stop();
-                                LeftVolumeAnimation().To(0.);
-                                RightVolumeAnimation().To(0.);
-                                VolumeStoryboard().Begin();
-                            }
-
-                            if (audioSessionsPeakTimer.IsRunning())
-                            {
-                                audioSessionsPeakTimer.Stop();
-                                for (auto&& view : audioSessionViews)
-                                {
-                                    view.SetPeak(0, 0);
-                                }
-                            }
+                            
 
                             // I18N: Translate battery saver messages.
                             WindowMessageBar().EnqueueString(L"Battery saver enabled, disabling animations.");
@@ -204,111 +147,32 @@ namespace winrt::Croak::implementation
                 {
                     DispatcherQueue().TryEnqueue([this]()
                     {
-                        if (DisableAnimationsIconToggleButton().IsOn())
-                        {
-                            if (!mainAudioEndpointPeakTimer.IsRunning())
-                            {
-                                mainAudioEndpointPeakTimer.Start();
-                            }
-
-                            if (!audioSessionsPeakTimer.IsRunning())
-                            {
-                                audioSessionsPeakTimer.Start();
-                            }
-
-                            // I18N: Translate battery saver messages.
-                            WindowMessageBar().EnqueueString(L"Battery saver disabled, re-enabling animations.");
-                            DisableAnimationsIconToggleButton().IsOn(false);
-                        }
+                        DisableAnimationsIconToggleButton().IsOn(false);
                     });
                     break;
                 }
             }
         });
 
-        PowerManager::UserPresenceStatusChanged([this](IInspectable, IInspectable)
-        {
-            auto userStatus = static_cast<int32_t>(PowerManager::UserPresenceStatus());
-
-            switch (userStatus)
-            {
-                case static_cast<int32_t>(UserPresenceStatus::Present):
-                {
-                    OutputDebugHString(L"User presence status changed: user present.");
-
-                    if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"PowerEfficiencyEnabled"), true))
-                    {
-                        DispatcherQueue().TryEnqueue([this]()
-                        {
-                            if (!mainAudioEndpointPeakTimer.IsRunning())
-                            {
-                                mainAudioEndpointPeakTimer.Start();
-                            }
-
-                            if (!audioSessionsPeakTimer.IsRunning())
-                            {
-                                audioSessionsPeakTimer.Start();
-                            }
-                        });
-                    }
-
-                    break;
-                }
-                case static_cast<int32_t>(UserPresenceStatus::Absent):
-                case 2:
-                {
-                    OutputDebugHString(L"User presence status changed: user absent.");
-
-                    if (
-                        unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"PowerEfficiencyEnabled"), true)
-                        )
-                    {
-                        DispatcherQueue().TryEnqueue([this]()
-                        {
-                            if (mainAudioEndpointPeakTimer.IsRunning())
-                            {
-                                mainAudioEndpointPeakTimer.Stop();
-                                LeftVolumeAnimation().To(0.);
-                                RightVolumeAnimation().To(0.);
-                                VolumeStoryboard().Begin();
-                            }
-
-                            if (audioSessionsPeakTimer.IsRunning())
-                            {
-                                audioSessionsPeakTimer.Stop();
-                                for (auto&& view : audioSessionViews)
-                                {
-                                    view.SetPeak(0, 0);
-                                }
-                            }
-                        });
-                    }
-                    break;
-                }
-            }
-        });
-
-
+        bool packageDifferentVersion = false;
         uint16_t lastMajor = 0;
         uint16_t lastMinor = 0;
         uint16_t lastBuild = 0;
-        bool packageDifferentVersion = false;
-
         Storage::PackageId packageId = Storage::Package::Current().Id();
-
         Storage::ApplicationDataContainer lastPackageIdContainer{ nullptr };
         if (Storage::ApplicationData::Current().LocalSettings().Containers().HasKey(L"PackageId"))
         {
             lastPackageIdContainer = Storage::ApplicationData::Current().LocalSettings().Containers().Lookup(L"PackageId");
+
             lastMajor = unbox_value<uint16_t>(lastPackageIdContainer.Values().Lookup(L"Major"));
             lastMinor = unbox_value<uint16_t>(lastPackageIdContainer.Values().Lookup(L"Minor"));
             lastBuild = unbox_value<uint16_t>(lastPackageIdContainer.Values().Lookup(L"Build"));
 
-            auto Major = packageId.Version().Major;
-            auto Minor = packageId.Version().Minor;
-            auto Build = packageId.Version().Build;
+            auto major = packageId.Version().Major;
+            auto minor = packageId.Version().Minor;
+            auto build = packageId.Version().Build;
 
-            packageDifferentVersion = Major != lastMajor || Minor != lastMinor || Build != lastBuild;
+            packageDifferentVersion = major != lastMajor || minor != lastMinor || build != lastBuild;
         }
         else
         {
@@ -321,6 +185,7 @@ namespace winrt::Croak::implementation
 
         if (packageDifferentVersion)
         {
+            // I18N: App has been updated && read notes here.
             Xaml::StackPanel panel{};
             Xaml::TextBlock block{};
             block.Text(L"App has been updated");
@@ -350,16 +215,7 @@ namespace winrt::Croak::implementation
 
     void MainWindow::Window_Activated(IInspectable const&, Xaml::WindowActivatedEventArgs const& e)
     {
-#if DEACTIVATE_TIMER
-        if (args.WindowActivationState() == WindowActivationState::Deactivated && audioSessionsPeakTimer.IsRunning())
-        {
-            audioSessionsPeakTimer.Stop();
-        }
-        else if (!audioSessionsPeakTimer.IsRunning())
-        {
-            audioSessionsPeakTimer.Start();
-        }
-#endif
+        windowActivated = e.WindowActivationState() != Xaml::WindowActivationState::Deactivated;
 
         if (e.WindowActivationState() == Xaml::WindowActivationState::Deactivated && 
             OverlayModeToggleButton().IsChecked().GetBoolean())
@@ -382,7 +238,7 @@ namespace winrt::Croak::implementation
             SetDragRectangles();
         }
 
-        if (appWindow.Size().Width < 210 && !compact)
+        /*if (appWindow.Size().Width < 210 && !compact)
         {
             compact = true;
 
@@ -401,60 +257,18 @@ namespace winrt::Croak::implementation
 
             MuteToggleButton().Visibility(Xaml::Visibility::Visible);
             SystemVolumeNumberBlock().Visibility(Xaml::Visibility::Visible);
-        }
-
-        SetSizeIndicators();
+        }*/
     }
 
-    void MainWindow::AudioSessionView_VolumeChanged(AudioSessionView const& sender, Xaml::RangeBaseValueChangedEventArgs const& args)
-    {
-        std::unique_lock lock{ audioSessionsMutex };
-        audioSessions.at(sender.Id())->Volume(static_cast<float>(args.NewValue() / 100.0));
-    }
-
-    void MainWindow::AudioSessionView_VolumeStateChanged(winrt::Croak::AudioSessionView const& sender, bool const& args)
-    {
-        std::unique_lock lock{ audioSessionsMutex };
-        audioSessions.at(sender.Id())->SetMute(args);
-    }
-
-    void MainWindow::AudioSessionsPanel_Loading(FrameworkElement const&, IInspectable const&)
+    void MainWindow::OnLoading(FrameworkElement const&, IInspectable const&)
     {
         LoadContent();
 
-        if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"LoadLastProfile"), true))
+        hstring profileName = unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"UserProfile"), L"");
+        if (!profileName.empty())
         {
-            hstring profileName = unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"AudioProfile"), L"");
-            if (!profileName.empty())
-            {
-                LoadAudioProfile(profileName);
-            }
+            LoadProfileByName(profileName);
         }
-
-#if ENABLE_HOTKEYS
-        // Activate hotkeys.
-        LoadHotKeys();
-#endif // ENABLE_HOTKEYS
-    }
-
-    void MainWindow::SystemVolumeSlider_ValueChanged(IInspectable const&, Xaml::RangeBaseValueChangedEventArgs const& e)
-    {
-        if (mainAudioEndpoint)
-        {
-            mainAudioEndpoint->Volume(static_cast<float>(e.NewValue() / 100.));
-        }
-
-        SystemVolumeNumberBlock().Double(e.NewValue());
-    }
-
-    void MainWindow::SystemVolumeActivityBorder_SizeChanged(IInspectable const&, Xaml::SizeChangedEventArgs const&)
-    {
-        SystemVolumeActivityBorderClippingRight().Rect(
-            Foundation::Rect(0, 0, static_cast<float>(SystemVolumeActivityBorderRight().ActualWidth()), static_cast<float>(SystemVolumeActivityBorderRight().ActualHeight()))
-        );
-        SystemVolumeActivityBorderClippingLeft().Rect(
-            Foundation::Rect(0, 0, static_cast<float>(SystemVolumeActivityBorderLeft().ActualWidth()), static_cast<float>(SystemVolumeActivityBorderLeft().ActualHeight()))
-        );
     }
 
     void MainWindow::HideMenuFlyoutItem_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
@@ -464,92 +278,22 @@ namespace winrt::Croak::implementation
 
     void MainWindow::SwitchStateMenuFlyoutItem_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        bool setMute = false;
-
-        uint32_t count = 0;
-        if (globalSessionAudioState == winrt::Croak::AudioSessionState::Unmuted)
-        {
-            for (auto&& view : audioSessionViews)
-            {
-                if (view.Muted())
-                {
-                    count++;
-                }
-            }
-
-            if (count != audioSessionViews.Size())
-            {
-                setMute = true;
-                globalSessionAudioState = AudioSessionState::Muted;
-            }
-        }
-        else if (globalSessionAudioState == winrt::Croak::AudioSessionState::Muted)
-        {
-            for (auto&& view : audioSessionViews)
-            {
-                if (!view.Muted())
-                {
-                    count++;
-                }
-            }
-
-            if (count == audioSessionViews.Size())
-            {
-                setMute = true;
-                globalSessionAudioState = AudioSessionState::Muted;
-            }
-            else
-            {
-                setMute = false;
-                globalSessionAudioState = AudioSessionState::Unmuted;
-            }
-        }
-
-        {
-            std::unique_lock lock{ audioSessionsMutex };
-            for (std::pair<guid, CAudio::AudioSession*> iter : audioSessions)
-            {
-                iter.second->Muted(setMute);
-            }
-        }
-
-        for (AudioSessionView view : audioSessionViews)
-        {
-            view.Muted(setMute);
-        }
+        // TODO: Switch state.
+       AudioViewer().SwitchAudioState();
     }
 
     void MainWindow::HorizontalViewMenuFlyoutItem_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        layout = 1;
-
-        AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
-        AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
-        AudioSessionsPanel().Style(
-            RootGrid().Resources().Lookup(box_value(L"GridViewHorizontalLayout")).as<Xaml::Style>());
-
         // Set DropDownButton to mimic ComboBox selected item behavior.
         Xaml::FontIcon icon{};
         icon.Glyph(L"\ue8c0");
         LayoutDropDownButton().Content(icon);
 
-        for (auto&& view : audioSessionViews)
-        {
-            view.Orientation(Xaml::Orientation::Vertical);
-        }
-
-        SetSizeIndicators();
+        AudioViewer().SetAudioSessionLayout(AudioSessionLayout::Horizontal);
     }
 
     void MainWindow::VerticalViewMenuFlyoutItem_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        layout = 2;
-
-        AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
-        AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
-        AudioSessionsPanel().Style(
-            RootGrid().Resources().Lookup(box_value(L"GridViewVerticalLayout")).as<Xaml::Style>());
-
         // Set DropDownButton to mimic ComboBox selected item behavior.
         Xaml::FontIcon icon{};
         icon.Glyph(L"\ue8c0");
@@ -557,35 +301,17 @@ namespace winrt::Croak::implementation
         icon.Rotation(90);
         LayoutDropDownButton().Content(icon);
 
-        for (auto&& view : audioSessionViews)
-        {
-            view.Orientation(Xaml::Orientation::Horizontal);
-        }
-
-        SetSizeIndicators();
+        AudioViewer().SetAudioSessionLayout(AudioSessionLayout::Vertical);
     }
 
     void MainWindow::AutoViewMenuFlyoutItem_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        AudioSessionsScrollViewer().HorizontalScrollBarVisibility(Xaml::ScrollBarVisibility::Disabled);
-        AudioSessionsScrollViewer().VerticalScrollBarVisibility(Xaml::ScrollBarVisibility::Auto);
-
-        AudioSessionsPanel().Style(
-            RootGrid().Resources().Lookup(box_value(L"GridViewHorizontalLayout")).as<Xaml::Style>()
-        );
-        layout = 0;
-
         // Set DropDownButton to mimic ComboBox selected item behavior.
         Xaml::FontIcon icon{};
         icon.Glyph(L"\uf0e2");
         LayoutDropDownButton().Content(icon);
 
-        for (auto&& view : audioSessionViews)
-        {
-            view.Orientation(Xaml::Orientation::Vertical);
-        }
-
-        SetSizeIndicators();
+        AudioViewer().SetAudioSessionLayout(AudioSessionLayout::Auto);
     }
 
     void MainWindow::SettingsIconButton_Click(IconButton const& /*sender*/, Xaml::RoutedEventArgs const& /*args*/)
@@ -603,61 +329,27 @@ namespace winrt::Croak::implementation
 
     void MainWindow::DisableHotKeysIconButton_Click(IconToggleButton const& /*sender*/, Xaml::RoutedEventArgs const& /*args*/)
     {
-#if ENABLE_HOTKEYS
-        /*ResourceLoader loader{};
-        if (muteHotKeyPtr.Enabled())
-        {
-            WindowMessageBar().EnqueueString(loader.GetString(L"InfoHotKeysEnabled"));
-        }
-        else
-        {
-            WindowMessageBar().EnqueueString(loader.GetString(L"InfoHotKeysDisabled"));
-        }*/
-#endif // ENABLE_HOTKEYS
+        hotKeysEnabled = !hotKeysEnabled;
+        ::Croak::System::HotKeys::HotKeyManager::GetHotKeyManager().EditKey(MOVE_WINDOW, hotKeysEnabled);
+
+        WindowMessageBar().EnqueueString(resourceLoader.GetString(hotKeysEnabled ? L"InfoHotKeysEnabled" : L"InfoHotKeysDisabled"));
+
         SettingsButtonFlyout().Hide();
     }
 
     void MainWindow::ShowAppBarIconButton_Click(IconToggleButton const& /*sender*/, Xaml::RoutedEventArgs const& /*args*/)
     {
-        AppBarGrid().Visibility(AppBarGrid().Visibility() == Xaml::Visibility::Visible ? Xaml::Visibility::Collapsed : Xaml::Visibility::Visible);
+        //AudioViewer().ShowAppBar();
     }
 
     void MainWindow::DisableAnimationsIconButton_Click(IconToggleButton const& /*sender*/, Xaml::RoutedEventArgs const& /*args*/)
     {
-        if (audioSessionsPeakTimer.IsRunning())
-        {
-            audioSessionsPeakTimer.Stop();
-        }
-        else
-        {
-            audioSessionsPeakTimer.Start();
-        }
-
-        if (mainAudioEndpointPeakTimer.IsRunning())
-        {
-            mainAudioEndpointPeakTimer.Stop();
-        }
-        else
-        {
-            mainAudioEndpointPeakTimer.Start();
-        }
-
-
-        LeftVolumeAnimation().To(0.);
-        RightVolumeAnimation().To(0.);
-        VolumeStoryboard().Begin();
-
-        for (auto&& view : audioSessionViews)
-        {
-            view.SetPeak(0, 0);
-        }
-        SettingsButtonFlyout().Hide();
+        
     }
 
     void MainWindow::MuteToggleButton_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        mainAudioEndpoint->SetMute(!mainAudioEndpoint->Muted());
-        MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
+        AudioViewer().MuteEndpoint();
     }
 
     void MainWindow::ViewHotKeysHyperlinkButton_Click(IInspectable const&, Xaml::RoutedEventArgs const&)
@@ -667,7 +359,7 @@ namespace winrt::Croak::implementation
     void MainWindow::SplashScreen_Dismissed(winrt::Croak::SplashScreen const&, Foundation::IInspectable const&)
     {
         WindowSplashScreen().Visibility(Xaml::Visibility::Collapsed);
-        ContentGrid().Visibility(Xaml::Visibility::Visible);
+        AudioViewer().Visibility(Xaml::Visibility::Visible);
     }
 
     void MainWindow::ExpandFlyoutButton_Click(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
@@ -700,68 +392,7 @@ namespace winrt::Croak::implementation
 
     void MainWindow::ReloadSessionsIconButton_Click(IconButton const&, Xaml::RoutedEventArgs const&)
     {
-        if (audioSessionsPeakTimer.IsRunning())
-        {
-            audioSessionsPeakTimer.Stop();
-        }
-        if (mainAudioEndpointPeakTimer.IsRunning())
-        {
-            mainAudioEndpointPeakTimer.Stop();
-        }
-
-        audioSessionViews.Clear();
-        VolumeStoryboard().Stop();
-
-        // Clean up ComPtr/IUnknown objects
-        if (audioController)
-        {
-            if (mainAudioEndpoint)
-            {
-                mainAudioEndpoint->StateChanged(mainAudioEndpointStateChangedToken);
-                mainAudioEndpoint->VolumeChanged(mainAudioEndpointVolumeChangedToken);
-                mainAudioEndpoint->Unregister();
-                mainAudioEndpoint->Release();
-            }
-
-            audioController->EndpointChanged(audioControllerEndpointChangedToken);
-            audioController->SessionAdded(audioControllerSessionAddedToken);
-
-            audioController->Unregister();
-            audioController->Release();
-        }
-
-        // Unregister VolumeChanged event handler & unregister audio sessions from audio events and release com ptrs.
-        {
-            std::unique_lock lock{ audioSessionsMutex };
-            for (std::pair<winrt::guid, CAudio::AudioSession*> it : audioSessions)
-            {
-                it.second->VolumeChanged(audioSessionVolumeChanged[it.first]);
-                it.second->StateChanged(audioSessionsStateChanged[it.first]);
-                it.second->Unregister();
-                it.second->Release();
-            }
-            audioSessions.clear();
-        }
-
-
-        // Reload content
-        LoadContent();
-        if (!DisableAnimationsIconToggleButton().IsOn())
-        {
-            if (mainAudioEndpoint)
-            {
-                mainAudioEndpointPeakTimer.Start();
-                VolumeStoryboard().Begin();
-            }
-
-            if (audioSessions.size() > 0u)
-            {
-                audioSessionsPeakTimer.Start();
-            }
-        }
-
-        Storage::ResourceLoader loader{};
-        WindowMessageBar().EnqueueString(loader.GetString(L"InfoAudioSessionsReloaded"));
+        AudioViewer().ReloadAudioSessions();
         SettingsButtonFlyout().Hide();
     }
 
@@ -769,8 +400,7 @@ namespace winrt::Croak::implementation
     {
         if (Microsoft::Windows::AppLifecycle::AppInstance::Restart(secondWindow ? L"-secondWindow" : L"") != Storage::Core::AppRestartFailureReason::RestartPending)
         {
-            Storage::ResourceLoader loader{};
-            WindowMessageBar().EnqueueString(loader.GetString(L"ErrorAppFailedRestart"));
+            WindowMessageBar().EnqueueString(resourceLoader.GetString(L"ErrorAppFailedRestart"));
         }
     }
 
@@ -789,7 +419,7 @@ namespace winrt::Croak::implementation
                 Xaml::ToggleButton item{};
                 item.Content(box_value(key));
                 item.Tag(box_value(key));
-                item.IsChecked(currentAudioProfile && (key == currentAudioProfile.ProfileName()));
+                item.IsChecked(currentProfile && (key == currentProfile.ProfileName()));
                 item.HorizontalAlignment(Xaml::HorizontalAlignment::Stretch);
                 item.Background(Xaml::SolidColorBrush(UI::Colors::Transparent()));
                 item.BorderThickness(Xaml::Thickness(0));
@@ -799,7 +429,7 @@ namespace winrt::Croak::implementation
                     MoreFlyoutStackpanel().Visibility(Xaml::Visibility::Visible);
                     ProfilesGrid().Visibility(Xaml::Visibility::Collapsed);
                     SettingsButtonFlyout().Hide();
-                    LoadAudioProfile(sender.as<FrameworkElement>().Tag().as<hstring>());
+                    LoadProfileByName(sender.as<FrameworkElement>().Tag().as<hstring>());
                 });
 
                 ProfilesStackpanel().Children().Append(item);
@@ -870,12 +500,7 @@ namespace winrt::Croak::implementation
 
     void MainWindow::ShowHiddenSessionsButton_Click(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
     {
-        /* 
-        * - Show hidden sessions, enable item selection.
-        * - Selected audio sessions will be hidden the next time 'show hidden buttons' is clicked.
-        * - Unselected audio sessions will be kept the next time 'show hidden buttons' is clicked.
-        */
-        // TODO: How do I insert the new sessions: lookup in the profile (if loaded) or insert at the end to not disrupt the UX too much.
+        AudioViewer().ShowHiddenAudioSessions();
     }
 
     void MainWindow::OverlayModeToggleButton_Click(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
@@ -899,8 +524,7 @@ namespace winrt::Croak::implementation
                 appWindow.MoveAndResize(rect);
             }
 
-            Storage::ResourceLoader loader{};
-            WindowMessageBar().EnqueueString(loader.GetString(L"OverlayModeEnabled")); // I18N
+            WindowMessageBar().EnqueueString(resourceLoader.GetString(L"OverlayModeEnabled")); // I18N
         }
         else 
         {
@@ -1005,10 +629,10 @@ namespace winrt::Croak::implementation
                 }
             }
 
-            LoadSettings();
+            currentProfile = LoadStartupProfile();
+            LoadSettings(currentProfile);
+            SetBackground();
         }
-
-        SetBackground();
     }
 
     void MainWindow::SetBackground()
@@ -1071,244 +695,7 @@ namespace winrt::Croak::implementation
 
     void MainWindow::LoadContent()
     {
-        Storage::ResourceLoader loader{};
-        GUID appID{};
-        if (SUCCEEDED(UuidCreate(&appID)))
-        {
-            try
-            {
-                // Create and setup audio interfaces.
-                audioController = new CAudio::AudioController(appID);
-
-                if (audioController->Register())
-                {
-                    audioController->SessionAdded({ this, &MainWindow::AudioController_SessionAdded });
-                    audioController->EndpointChanged({ this, &MainWindow::AudioController_EndpointChanged });
-                }
-                else
-                {
-                    WindowMessageBar().EnqueueString(loader.GetString(L"ErrorAudioSessionsUnavailable"));
-                }
-
-                mainAudioEndpoint = audioController->GetMainAudioEndpoint();
-                if (mainAudioEndpoint->Register())
-                {
-                    mainAudioEndpointVolumeChangedToken = mainAudioEndpoint->VolumeChanged({ this, &MainWindow::MainAudioEndpoint_VolumeChanged });
-                    mainAudioEndpointStateChangedToken = mainAudioEndpoint->StateChanged([this](IInspectable, bool muted)
-                    {
-                        DispatcherQueue().TryEnqueue([this, muted]()
-                        {
-                            MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
-                            MuteToggleButtonFontIcon().Glyph(muted ? L"\ue74f" : L"\ue767");
-                        });
-                    });
-                }
-
-                // TODO: Check code validity, no memory leaks, performance.
-                auto audioSessionsVector = std::unique_ptr<std::vector<CAudio::AudioSession*>>();
-                try
-                {
-                    audioSessionsVector = std::unique_ptr<std::vector<CAudio::AudioSession*>>(audioController->GetSessions());
-                    for (size_t i = 0; i < audioSessionsVector->size(); i++)
-                    {
-                        audioSessions.insert({ guid(audioSessionsVector->at(i)->Id()), audioSessionsVector->at(i) });
-
-                        // Check if the session is active, if not check if the user asked to show inactive sessions on startup.
-                        if (audioSessionsVector->at(i)->State() == ::AudioSessionState::AudioSessionStateActive ||
-                            unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"ShowInactiveSessionsOnStartup"), true))
-                        {
-                            if (AudioSessionView view = CreateAudioView(audioSessionsVector->at(i)))
-                            {
-                                audioSessionViews.Append(view);
-                            }
-                        }
-                        else // Register to events since we are not adding/creating the view.
-                        {
-                            if (audioSessionsVector->at(i)->Register())
-                            {
-                                audioSessionVolumeChanged.insert({ audioSessionsVector->at(i)->Id(), audioSessionsVector->at(i)->VolumeChanged({ this, &MainWindow::AudioSession_VolumeChanged }) });
-                                audioSessionsStateChanged.insert({ audioSessionsVector->at(i)->Id(), audioSessionsVector->at(i)->StateChanged({ this, &MainWindow::AudioSession_StateChanged }) });
-                            }
-                            else
-                            {
-                                //DebugLog(format(L"Failed to register audio session '{0}'. This session will never be shown.", audioSessionsVector->at(i)->Name()));
-                                OutputDebugWString(L"Failed to register audio session '" + audioSessionsVector->at(i)->Name() + L"'. This session will never be shown.");
-                                WindowMessageBar().EnqueueString(audioSessionsVector->at(i)->Name() + L" : notifications off");
-                            }
-                        }
-                    }
-                }
-                catch (const hresult_error&)
-                {
-                    if (audioSessionsVector.get())
-                    {
-                        for (size_t j = 0; j < audioSessionsVector->size(); j++)
-                        {
-                            audioSessionsVector->at(j)->Release();
-                        }
-
-                        auto vect = audioSessionsVector.release();
-                        delete vect;
-                    }
-
-                    throw;
-                }
-
-
-                // Create and setup peak meters timers
-                audioSessionsPeakTimer = DispatcherQueue().CreateTimer();
-                mainAudioEndpointPeakTimer = DispatcherQueue().CreateTimer();
-
-                audioSessionsPeakTimer.Interval(Foundation::TimeSpan(std::chrono::milliseconds(83)));
-                audioSessionsPeakTimer.Tick({ this, &MainWindow::UpdatePeakMeters });
-                audioSessionsPeakTimer.Stop();
-
-                mainAudioEndpointPeakTimer.Interval(Foundation::TimeSpan(std::chrono::milliseconds(83)));
-                mainAudioEndpointPeakTimer.Tick([&](auto, auto)
-                {
-                    if (!loaded)
-                    {
-                        return;
-                    }
-
-                    try
-                    {
-                        std::pair<float, float> peakValues = mainAudioEndpoint->GetPeaks();
-                        LeftVolumeAnimation().To(static_cast<double>(peakValues.first));
-                        RightVolumeAnimation().To(static_cast<double>(peakValues.second));
-                        VolumeStoryboard().Begin();
-                    }
-                    catch (const hresult_error&)
-                    {
-                        // TODO: Handle error.
-                    }
-                });
-
-                MainEndpointNameTextBlock().Text(mainAudioEndpoint->Name());
-                SystemVolumeSlider().Value(static_cast<double>(mainAudioEndpoint->Volume()) * 100.);
-                MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
-                MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
-            }
-            catch (const hresult_error& ex)
-            {
-                WindowMessageBar().EnqueueString(loader.GetString(L"ErrorFatalFailure"));
-                OutputDebugHString(ex.message());
-            }
-        }
-        else
-        {
-            WindowMessageBar().EnqueueString(loader.GetString(L"ErrorFatalFailure"));
-        }
-    }
-
-    AudioSessionView MainWindow::CreateAudioView(CAudio::AudioSession* audioSession)
-    {
-        if (audioSession->Register())
-        {
-            audioSessionVolumeChanged.insert({ audioSession->Id(), audioSession->VolumeChanged({ this, &MainWindow::AudioSession_VolumeChanged }) });
-            audioSessionsStateChanged.insert({ audioSession->Id(), audioSession->StateChanged({ this, &MainWindow::AudioSession_StateChanged }) });
-        }
-        else
-        {
-            OutputDebugWString(L"Failed to register audio session '" + audioSession->Name() + L"'.");
-            WindowMessageBar().EnqueueString(audioSession->Name() + L" notifications off");
-        }
-
-        return CreateAudioSessionView(audioSession, false);
-    }
-
-    AudioSessionView MainWindow::CreateAudioSessionView(CAudio::AudioSession* audioSession, bool skipDuplicates)
-    {
-        // Check for duplicates, multiple audio sessions might be grouped under one by the app/system owning the sessions.
-        //checkForDuplicates = false;
-        if (!skipDuplicates && audioSession->State() != ::AudioSessionState::AudioSessionStateActive)
-        {
-            std::unique_lock lock{ audioSessionsMutex };
-
-            uint8_t hitcount = 0u;
-            for (auto& iter : audioSessions)
-            {
-                if (iter.second->GroupingParam() == audioSession->GroupingParam())
-                {
-                    if (hitcount > 1)
-                    {
-                        return nullptr;
-                    }
-                    hitcount++;
-                }
-            }
-        }
-
-        AudioSessionView view = nullptr;
-        if (audioSession->IsSystemSoundSession())
-        {
-            view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
-
-            Xaml::FontIcon icon{};
-            icon.Glyph(L"\ue977");
-            // #5FDFFF
-            icon.Foreground(
-                Xaml::SolidColorBrush(Xaml::Application::Current().Resources().TryLookup(box_value(L"WindowsLogoColor")).as<Windows::UI::Color>())
-            );
-            Xaml::Viewbox iconViewbox{};
-            iconViewbox.HorizontalAlignment(Xaml::HorizontalAlignment::Stretch);
-            iconViewbox.VerticalAlignment(Xaml::VerticalAlignment::Stretch);
-            iconViewbox.Child(icon);
-            view.Logo().Content(iconViewbox);
-        }
-        else
-        {
-            if (!audioSession->ProcessInfo()->Manifest().Logo().empty())
-            {
-                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
-
-                Xaml::BitmapImage imageSource{};
-                imageSource.UriSource(Foundation::Uri(audioSession->ProcessInfo()->Manifest().Logo()));
-                Xaml::Image image{};
-                image.Source(imageSource);
-
-                view.Logo().Content(image);
-            }
-            else if (!audioSession->ProcessInfo()->ExecutablePath().empty())
-            {
-                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0, audioSession->ProcessInfo()->ExecutablePath());
-            }
-            else
-            {
-                view = AudioSessionView(audioSession->Name(), audioSession->Volume() * 100.0);
-            }
-        }
-
-        view.Id(guid(audioSession->Id()));
-        view.Muted(audioSession->Muted());
-        view.SetState((AudioSessionState)audioSession->State());
-        view.Orientation(layout == 2 ? Xaml::Orientation::Horizontal : Xaml::Orientation::Vertical);
-
-        view.VolumeChanged({ this, &MainWindow::AudioSessionView_VolumeChanged });
-        view.VolumeStateChanged({ this, &MainWindow::AudioSessionView_VolumeStateChanged });
-        view.Hidden([this](AudioSessionView sender, auto)
-        {
-#ifdef DEBUG
-
-#else
-            for (auto const& view : audioSessionViews)
-            {
-                if (view.Id() == sender.Id())
-                {
-                    uint32_t indexOf = 0;
-                    if (audioSessionViews.IndexOf(view, indexOf))
-                    {
-                        audioSessionViews.RemoveAt(indexOf);
-                    }
-
-                    return;
-                }
-            }
-#endif // DEBUG
-
-        });
-
-        return view;
+        // UNDONE: Remove
     }
 
     void MainWindow::SetDragRectangles()
@@ -1316,83 +703,65 @@ namespace winrt::Croak::implementation
         Graphics::RectInt32 dragRectangle{};
 
         dragRectangle.X = static_cast<int32_t>(LeftPaddingColumn().ActualWidth() + SettingsButtonColumn().ActualWidth());
+#ifdef DEBUG
+        dragRectangle.Y = 7;
+#else
         dragRectangle.Y = 0;
+#endif
         dragRectangle.Width = static_cast<int32_t>(TitleBarGrid().ActualWidth() - (LeftPaddingColumn().ActualWidth() + SettingsButtonColumn().ActualWidth()));
         dragRectangle.Height = static_cast<int32_t>(TitleBarGrid().ActualHeight());
 
         appWindow.TitleBar().SetDragRectangles(std::vector<Graphics::RectInt32>{ dragRectangle });
     }
 
-    void MainWindow::SaveAudioLevels()
-    {
-        Storage::ApplicationDataContainer audioLevels = Storage::ApplicationData::Current().LocalSettings().CreateContainer(
-            L"AudioLevels",
-            Storage::ApplicationData::Current().LocalSettings().Containers().HasKey(L"AudioLevels") ? Storage::ApplicationDataCreateDisposition::Existing : Storage::ApplicationDataCreateDisposition::Always
-        );
-
-        for (uint32_t i = 0; i < audioSessionViews.Size(); i++) // Only saving the visible audio sessions levels.
-        {
-            Storage::ApplicationDataCompositeValue compositeValue{};
-            compositeValue.Insert(L"Muted", box_value(audioSessionViews.GetAt(i).Muted()));
-            compositeValue.Insert(L"Level", box_value(audioSessionViews.GetAt(i).Volume()));
-            if (!audioSessionViews.GetAt(i).Header().empty())
-            {
-                audioLevels.Values().Insert(audioSessionViews.GetAt(i).Header(), compositeValue);
-            }
-        }
-    }
-
     void MainWindow::LoadHotKeys()
     {
-        ::Croak::System::HotKeys::HotKeyManager& hotKeyManager = ::Croak::System::HotKeys::HotKeyManager::GetHotKeyManager();
+        using namespace ::Croak::System::HotKeys;
+        HotKeyManager& hotKeyManager = HotKeyManager::GetHotKeyManager();
         hotKeyManager.HotKeyFired({ this, &MainWindow::HotKeyFired });
 
         try
         {
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Windows | Windows::System::VirtualKeyModifiers::Control, VK_DOWN, true, VOLUME_DOWN);
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Windows | Windows::System::VirtualKeyModifiers::Control, VK_UP, true, VOLUME_UP);
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Menu, VK_UP, true, VOLUME_UP_ALT);
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Menu, VK_DOWN, true, VOLUME_DOWN_ALT);
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Control | Windows::System::VirtualKeyModifiers::Shift, 'M', true, MUTE_SYSTEM);
-
             hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Menu, VK_SPACE, true, MOVE_WINDOW);
-            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Menu, 'A', true, MOVE_WINDOW);
         }
         catch (const std::invalid_argument& ex)
         {
-            DebugLog(std::format("Could not register hot key.\n\t{0}", ex.what()));
-            WindowMessageBar().EnqueueMessage(box_value(L"Failed to enable some hot keys."));
+            DebugLog(std::format("Could not register MOVE_WINDOW.\n\t{0}", ex.what()));
+            // TODO: I18N
+            WindowMessageBar().EnqueueString(
+                L"Alt + Space hot key not enabled"
+            );
+        }
+
+        try
+        {
+            hotKeyManager.RegisterHotKey(Windows::System::VirtualKeyModifiers::Menu, 'A', true, MOVE_WINDOW_ALT);
+        }
+        catch (const std::invalid_argument& ex)
+        {
+            DebugLog(std::format("Could not register MOVE_WINDOW_ALT.\n\t{0}", ex.what()));
+            WindowMessageBar().EnqueueString(
+                L"Alt + A hot key not enabled"
+            );
         }
     }
 
-    void MainWindow::LoadSettings()
+    void MainWindow::LoadSettings(const UserProfile& profile)
     {
-        Collections::IPropertySet settings = Storage::ApplicationData::Current().LocalSettings().Values();
-
-        Graphics::RectInt32 rect{};
-        rect.Width = unbox_value_or(
-            settings.TryLookup(L"WindowWidth"),
-            Xaml::Application::Current().Resources().Lookup(box_value(L"WindowWidth")).as<int32_t>()
-        );
-        rect.Height = unbox_value_or(
-            settings.TryLookup(L"WindowHeight"),
-            Xaml::Application::Current().Resources().Lookup(box_value(L"WindowHeight")).as<int32_t>()
-        );
-        rect.X = unbox_value_or(settings.TryLookup(L"WindowPosX"), -1);
-        rect.Y = unbox_value_or(settings.TryLookup(L"WindowPosY"), -1);
+        Graphics::RectInt32 rect = profile.WindowDisplayRect();
         UI::DisplayArea display = UI::DisplayArea::GetFromPoint(Graphics::PointInt32(rect.X, rect.Y), UI::DisplayAreaFallback::None);
-        if (!display || rect.X < 0 || rect.Y < 0)
+        if (!display || rect.X < 0 || rect.Y < 0) //TODO: Check if rect.X < 0 and rect.Y < 0 are right when the current display is on the left of the main display.
         {
             display = UI::DisplayArea::GetFromPoint(Graphics::PointInt32(rect.X, rect.Y), UI::DisplayAreaFallback::Primary);
-            rect.X = display.WorkArea().X + 10;
-            rect.Y = display.WorkArea().X + 10;
+            // Set window middle of the screen.
+            rect.X = (display.WorkArea().Width / 2) - (rect.Width / 2);
+            rect.Y = (display.WorkArea().Height / 2) - (rect.Height / 2);
         }
         appWindow.MoveAndResize(rect);
 
-
         auto&& presenter = appWindow.Presenter().as<UI::OverlappedPresenter>();
-        bool alwaysOnTop = unbox_value_or(settings.TryLookup(L"IsAlwaysOnTop"), false);
-        UI::OverlappedPresenterState presenterState = static_cast<UI::OverlappedPresenterState>(unbox_value_or(settings.TryLookup(L"PresenterState"), 2));
+        bool alwaysOnTop = profile.IsAlwaysOnTop();
+        UI::OverlappedPresenterState presenterState = profile.PresenterState();
         switch (presenterState)
         {
             case UI::OverlappedPresenterState::Maximized:
@@ -1413,65 +782,52 @@ namespace winrt::Croak::implementation
         ));
         presenter.IsAlwaysOnTop(alwaysOnTop);
 
-        layout = unbox_value_or(settings.TryLookup(L"SessionsLayout"), 0);
-
         PipToggleButton().IsChecked(alwaysOnTop);
-        DisableAnimationsIconToggleButton().IsOn(unbox_value_or(settings.TryLookup(L"DisableAnimations"), false));
-        bool showMenu = unbox_value_or(settings.TryLookup(L"ShowAppBar"), false);
-        ShowAppBarIconToggleButton().IsOn(showMenu);
-        if (showMenu)
+        DisableAnimationsIconToggleButton().IsOn(profile.AudioProfile().DisableAnimations());
+        ShowAppBarIconToggleButton().IsOn(profile.AudioProfile().ShowMenu());
+
+#ifdef ENABLE_HOTKEYS
+        // Activate hotkeys.
+        if (profile.HotKeysEnabled())
         {
-            AppBarGrid().Visibility(Xaml::Visibility::Visible);
+            LoadHotKeys();        
         }
+#endif // ENABLE_HOTKEYS
     }
 
     void MainWindow::SaveSettings()
     {
         Collections::IPropertySet settings = Storage::ApplicationData::Current().LocalSettings().Values();
-        settings.Insert(L"WindowHeight", box_value(displayRect.Height));
-        settings.Insert(L"WindowWidth", box_value(displayRect.Width));
-        settings.Insert(L"WindowPosX", box_value(displayRect.X));
-        settings.Insert(L"WindowPosY", box_value(displayRect.Y));
 
-        auto presenter = appWindow.Presenter().as<UI::OverlappedPresenter>();
-        settings.Insert(L"IsAlwaysOnTop", box_value(presenter.IsAlwaysOnTop()));
-        settings.Insert(L"PresenterState", box_value(static_cast<int32_t>(presenter.State())));
+        settings.Insert(L"LastUsedUserProfile", box_value(currentProfile.ProfileName()));
 
-        settings.Insert(L"DisableAnimations", box_value(DisableAnimationsIconToggleButton().IsOn()));
-        settings.Insert(L"SessionsLayout", Foundation::IReference<int32_t>(layout));
-        settings.Insert(L"ShowAppBar", box_value(ShowAppBarIconToggleButton().IsOn()));
-
-        if (currentAudioProfile)
+        if (!currentProfile.Frozen())
         {
-            settings.Insert(L"AudioProfile", box_value(currentAudioProfile.ProfileName()));
+            // Update current profile
+            auto presenter = appWindow.Presenter().as<UI::OverlappedPresenter>();
+            currentProfile.PresenterState(presenter.State());
+            currentProfile.IsAlwaysOnTop(appWindow.Presenter().as<UI::OverlappedPresenter>().IsAlwaysOnTop());
+            currentProfile.WindowDisplayRect(displayRect);
 
-            if (unbox_value_or(settings.TryLookup(L"AllowChangesToLoadedProfile"), false))
+            // If the user has a profile, the AudioProfile container has to exist, so no TryLookup and container creation.
+            Storage::ApplicationDataContainer userProfiles = nullptr;
+            if (!Storage::ApplicationData::Current().LocalSettings().Containers().HasKey(L"UserProfiles"))
             {
-                currentAudioProfile.SystemVolume(mainAudioEndpoint->Volume());
-                currentAudioProfile.Layout(layout);
-                currentAudioProfile.KeepOnTop(appWindow.Presenter().as<UI::OverlappedPresenter>().IsAlwaysOnTop());
-                currentAudioProfile.ShowMenu(AppBarGrid().Visibility() == Xaml::Visibility::Visible);
-                currentAudioProfile.DisableAnimations(mainAudioEndpointPeakTimer.IsRunning());
-
-                std::unique_lock lock{ audioSessionsMutex };
-                for (std::pair<winrt::guid, CAudio::AudioSession*> iter : audioSessions)
-                {
-                    auto name = iter.second->Name();
-                    auto muted = iter.second->Muted();
-                    auto volume = iter.second->Volume();
-
-                    currentAudioProfile.AudioSessionsSettings().Append(AudioSessionSettings(name, muted, volume));
-                }
-
-                // If the user has a profile, the AudioProfile container has to exist, so no TryLookup and container creation.
-                currentAudioProfile.Save(Storage::ApplicationData::Current().LocalSettings().Containers().Lookup(L"AudioProfiles"));
+                userProfiles = Storage::ApplicationData::Current().LocalSettings().CreateContainer(L"UserProfiles", Storage::ApplicationDataCreateDisposition::Always);
             }
+            else
+            {
+                userProfiles = Storage::ApplicationData::Current().LocalSettings().Containers().Lookup(L"UserProfiles");
+            }
+            Storage::ApplicationDataContainer profileContainer = userProfiles.CreateContainer(currentProfile.ProfileName(),
+                Storage::ApplicationDataCreateDisposition::Always);
+            currentProfile.Save(profileContainer);
         }
     }
 
-    void MainWindow::LoadAudioProfile(const hstring& profileName)
+    void MainWindow::LoadProfileByName(const hstring& profileName)
     {
-        Storage::ApplicationDataContainer audioProfilesContainer = Storage::ApplicationData::Current().LocalSettings().Containers().TryLookup(L"AudioProfiles");
+        Storage::ApplicationDataContainer audioProfilesContainer = Storage::ApplicationData::Current().LocalSettings().Containers().TryLookup(L"UserProfiles");
         if (audioProfilesContainer)
         {
             for (auto&& profile : audioProfilesContainer.Containers())
@@ -1481,21 +837,12 @@ namespace winrt::Croak::implementation
                     hstring name = profile.Key();
                     if (name == profileName)
                     {
-#pragma region Basic profile stuff
-                        AudioProfile audioProfile{};
-                        audioProfile.Restore(profile.Value()); // If the restore fails, the next instructions will not be ran.
-                        currentAudioProfile = std::move(audioProfile);
+                        UserProfile userProfile{};
+                        userProfile.Restore(profile.Value()); // If the restore fails, the next instructions will not be ran.
+                        currentProfile = std::move(userProfile);
                         // Cannot use audioProfile variable below here.
 
-                        bool disableAnimations = currentAudioProfile.DisableAnimations();
-                        bool keepOnTop = currentAudioProfile.KeepOnTop();
-                        bool showMenu = currentAudioProfile.ShowMenu();
-                        uint32_t windowLayout = currentAudioProfile.Layout();
-
-                        if (disableAnimations)
-                        {
-                            DisableAnimationsIconButton_Click(nullptr, nullptr);
-                        }
+                        bool keepOnTop = currentProfile.IsAlwaysOnTop();
 
                         if (UI::OverlappedPresenter presenter = appWindow.Presenter().try_as<UI::OverlappedPresenter>())
                         {
@@ -1509,177 +856,13 @@ namespace winrt::Croak::implementation
                             RightPaddingColumn().Width(Xaml::GridLengthHelper::FromPixels(keepOnTop ? 45 : 135));
                         }
 
-                        if (showMenu)
+#ifdef ENABLE_HOTKEYS
+                        if (currentProfile.HotKeysEnabled())
                         {
-                            ShowAppBarIconButton_Click(nullptr, nullptr);
+                            // Activate hotkeys.
+                            LoadHotKeys();
                         }
-
-                        switch (windowLayout)
-                        {
-                            case 1:
-                                HorizontalViewMenuFlyoutItem_Click(nullptr, nullptr);
-                                break;
-                            case 2:
-                                VerticalViewMenuFlyoutItem_Click(nullptr, nullptr);
-                                break;
-                            case 0:
-                            default:
-                                AutoViewMenuFlyoutItem_Click(nullptr, nullptr);
-                                break;
-                        }
-#pragma endregion
-
-                        AudioSessionsPanel().ItemsSource(nullptr);
-
-                        // Finish loading profile in non-UI thread.
-                        concurrency::task<void> t = concurrency::task<void>([this]()
-                        {
-                            try
-                            {
-                                // Set system volume.
-                                float systemVolume = currentAudioProfile.SystemVolume();
-                                mainAudioEndpoint->SetVolume(systemVolume);
-
-                                // Set audio sessions volume.
-                                std::unique_lock lock{ audioSessionsMutex }; // Taking the lock will also lock sessions from being added to the display.
-
-                                auto audioSessionsSettings = currentAudioProfile.AudioSessionsSettings();
-                                for (auto&& audioSessionSettings : audioSessionsSettings)
-                                {
-                                    for (std::pair<winrt::guid, CAudio::AudioSession*> iter : audioSessions)
-                                    {
-                                        if (iter.second->Name() == audioSessionSettings.Name())
-                                        {
-                                            iter.second->SetVolume(audioSessionSettings.AudioLevel());
-                                            iter.second->SetMute(audioSessionSettings.Muted());
-                                        }
-                                    }
-                                }
-
-                                std::vector<AudioSessionView> uniqueSessions{};
-                                // HACK: IVector<T>::GetMany does not seem to work. Manual copy.
-                                for (uint32_t i = 0; i < audioSessionViews.Size(); i++)
-                                {
-                                    uniqueSessions.push_back(audioSessionViews.GetAt(i));
-                                }
-
-                                auto indexes = currentAudioProfile.SessionsIndexes();
-                                auto&& views = std::vector<AudioSessionView>(indexes.Size(), nullptr);
-                                for (size_t i = 0; i < uniqueSessions.size(); i++)
-                                {
-                                    auto&& view = uniqueSessions[i];
-
-                                    auto opt = indexes.TryLookup(view.Header());
-                                    if (opt.has_value())
-                                    {
-                                        size_t index = opt.value();
-                                        if (index < views.size())
-                                        {
-                                            // The index might already be populated by the else if/else statements when the index is over the collection size.
-                                            if (views[index] == nullptr)
-                                            {
-                                                views[index] = view;
-                                            }
-                                            else
-                                            {
-                                                views.push_back(views[index]);
-                                                views[index] = view;
-                                            }
-                                        }
-                                        else if (views[views.size() - 1] == nullptr) // Check if the last index of the collection is free.
-                                        {
-                                            views[views.size() - 1] = view;
-                                        }
-                                        else // The index is over the collection size and the last value of the collection is already populated.
-                                        {
-                                            views.push_back(view);
-                                        }
-
-                                        uniqueSessions[i] = nullptr; // Set to null to tell the session has been added.
-                                    }
-                                }
-
-                                // Add the sessions that were not in the profile.
-                                // Try to add the session where there is still space. If not possible, append it.
-                                bool hasTrailingNullptrs = true;
-                                for (size_t i = 0; i < uniqueSessions.size(); i++)
-                                {
-                                    if (uniqueSessions[i])
-                                    {
-                                        int j = static_cast<int>(views.size()) - 1;
-                                        for (; j >= 0; j--)
-                                        {
-                                            if (views[j] == nullptr)
-                                            {
-                                                views[j] = uniqueSessions[i];
-                                                break;
-                                            }
-                                        }
-
-                                        if (j < 0)
-                                        {
-                                            views.push_back(uniqueSessions[i]);
-                                            hasTrailingNullptrs = false;
-                                        }
-                                    }
-                                }
-
-                                if (hasTrailingNullptrs)
-                                {
-                                    //HACK: Clear null values by passing another time through the view array.
-                                    size_t finalSize = views.size();
-                                    for (size_t i = 0; i < views.size(); i++)
-                                    {
-                                        if (views[i] == nullptr)
-                                        {
-                                            size_t j = i + 1;
-                                            while (j < views.size() && views[j] == nullptr)
-                                            {
-                                                j++;
-                                            }
-
-                                            if (j < views.size())
-                                            {
-                                                views[i] = std::move(views[j]);
-                                            }
-                                            else
-                                            {
-                                                finalSize--;
-                                            }
-                                        }
-                                    }
-                                    views.resize(finalSize);
-                                }
-
-                                audioSessionViews = multi_threaded_observable_vector<AudioSessionView>(move(views));
-                                DispatcherQueue().TryEnqueue([this]()
-                                {
-                                    // HACK: Can we use INotifyPropertyChanged to raise that the vector has changed ?
-                                    AudioSessionsPanel().ItemsSource(audioSessionViews);
-
-                                    // I18N: Loaded profile [profile name]
-                                    WindowMessageBar().EnqueueString(L"Loaded profile " + currentAudioProfile.ProfileName());
-                                });
-                            }
-                            catch (const std::out_of_range& ex)
-                            {
-                                // TODO: Log exception to EventViewer to enable app analysis.
-                                OutputDebugHString(to_hstring(ex.what()));
-                                DispatcherQueue().TryEnqueue([this]()
-                                {
-                                    WindowMessageBar().EnqueueString(L"Couldn't load profile " + currentAudioProfile.ProfileName());
-                                });
-                            }
-                            catch (const hresult_error& err)
-                            {
-                                // I18N: Failed to load profile [profile name]
-                                OutputDebugHString(err.message());
-                                DispatcherQueue().TryEnqueue([this]()
-                                {
-                                    WindowMessageBar().EnqueueString(L"Couldn't load profile " + currentAudioProfile.ProfileName());
-                                });
-                            }
-                        });
+#endif // ENABLE_HOTKEYS
                     }
                 }
                 catch (const hresult_error& error)
@@ -1692,376 +875,88 @@ namespace winrt::Croak::implementation
         }
     }
 
-    void MainWindow::ReloadAudioSessions()
+    winrt::Croak::UserProfile MainWindow::LoadStartupProfile()  
     {
-        if (audioSessionsPeakTimer.IsRunning())
+        // If `profileName` is empty, create a default profile for the application to use until the user creates it's own or uses the default profile as his.
+        winrt::hstring profileName = unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"LastUsedUserProfile"), L"");
+        UserProfile profile = CreateDefaultProfile();
+        if (!profileName.empty())
         {
-            audioSessionsPeakTimer.Stop();
-        }
-
-        audioSessionViews.Clear();
-        VolumeStoryboard().Stop();
-
-        // Unregister VolumeChanged event handler & unregister audio sessions from audio events and release com ptrs.
-        {
-            std::unique_lock lock{ audioSessionsMutex };
-            for (auto& iter : audioSessions)
+            Storage::ApplicationDataContainer container = Storage::ApplicationData::Current().LocalSettings().Containers().TryLookup(L"UserProfiles");
+            if (container)
             {
-                iter.second->VolumeChanged(audioSessionVolumeChanged[iter.first]);
-                iter.second->StateChanged(audioSessionsStateChanged[iter.first]);
-                iter.second->Unregister();
-                iter.second->Release();
-            }
-            audioSessions.clear();
-            // The lock can be realeased since no interactions will be made with audioSessions && audioSessionViews
-        }
-
-        try
-        {
-            // Reload audio sessions.
-            auto audioSessionsVect = audioController->GetSessions();
-            audioSessions = MapAudioSessions(audioSessionsVect);
-            for (size_t i = 0; i < audioSessionsVect->size(); i++)
-            {
-                if (AudioSessionView view = CreateAudioView(audioSessionsVect->at(i)))
+                Storage::ApplicationDataContainer profileContainer = container.Containers().TryLookup(profileName);
+                if (profileContainer)
                 {
-                    audioSessionViews.Append(view);
+                    try
+                    {
+                        profile.Restore(profileContainer); // If the restore fails, its going to throw.
+                    }
+                    catch (winrt::hresult_error)
+                    {
+                        // TODO: Handle error.
+                        WindowMessageBar().EnqueueString(resourceLoader.GetString(L"LoadProfileFailed"));
+                    }
                 }
             }
-
-            if (!DisableAnimationsIconToggleButton().IsOn())
-            {
-                audioSessionsPeakTimer.Start();
-            }
         }
-        catch (const winrt::hresult_error& err)
-        {
-            OutputDebugHString(L"Failed to reload audio sessions: " + err.message());
-        }
+        return profile;
     }
 
-    std::map<guid, CAudio::AudioSession*> MainWindow::MapAudioSessions(std::vector<CAudio::AudioSession*>* vect)
+    winrt::Croak::UserProfile MainWindow::CreateDefaultProfile()
     {
-        std::map<guid, CAudio::AudioSession*> audioSessionsMap{};
-
-        for (size_t i = 0; i < vect->size(); i++)
+        try
         {
-            audioSessions.insert({ guid(vect->at(i)->Id()), vect->at(i) });
+            UserProfile defaultProfile{};
+            defaultProfile.Frozen(false);
+            winrt::hstring defaultProfileName = resourceLoader.GetString(L"DefaultProfileName");
+            defaultProfile.ProfileName(defaultProfileName);
+            // Set default window position and size.
+            Graphics::RectInt32 windowDisplayRect{};
+            windowDisplayRect.Width = Xaml::Application::Current().Resources().Lookup(winrt::box_value(L"WindowWidth")).as<int32_t>();
+            windowDisplayRect.Height = Xaml::Application::Current().Resources().Lookup(winrt::box_value(L"WindowHeight")).as<int32_t>();
+            auto display = UI::DisplayArea::GetFromPoint(Graphics::PointInt32(0, 0), UI::DisplayAreaFallback::Primary);
+            // Set window middle of the screen.
+            windowDisplayRect.X = (display.WorkArea().Width / 2) - (windowDisplayRect.Width / 2);
+            windowDisplayRect.Y = (display.WorkArea().Height / 2) - (windowDisplayRect.Height / 2);
+            defaultProfile.WindowDisplayRect(windowDisplayRect);
+
+            AudioProfile defaultAudioProfile{};
+            defaultAudioProfile.ProfileName(defaultProfileName);
+            defaultAudioProfile.IsDefaultProfile(true);
+
+            defaultProfile.AudioProfile(defaultAudioProfile);
+
+            return defaultProfile;
         }
-
-        return move(audioSessionsMap);
-    }
-
-    void MainWindow::CleanUpResources(const bool& forReload)
-    {
-        if (audioSessionsPeakTimer && audioSessionsPeakTimer.IsRunning())
+        catch (const winrt::hresult_error& ex)
         {
-            audioSessionsPeakTimer.Stop();
+            DebugBreak();
         }
-
-        if (!forReload && mainAudioEndpointPeakTimer && mainAudioEndpointPeakTimer.IsRunning())
+        catch (const std::exception& ex)
         {
-            mainAudioEndpointPeakTimer.Stop();
-        }
-
-        VolumeStoryboard().Stop();
-
-        // Unregister VolumeChanged event handler & unregister audio sessions from audio events and release com ptrs.
-        if (audioSessions.size() > 0)
-        {
-            std::unique_lock lock{ audioSessionsMutex };
-
-            for (std::pair<winrt::guid, CAudio::AudioSession*> iter : audioSessions)
-            {
-                iter.second->VolumeChanged(audioSessionVolumeChanged[iter.first]);
-                iter.second->StateChanged(audioSessionsStateChanged[iter.first]);
-                assert(iter.second->Unregister());
-                assert(iter.second->Release() == 0);
-            }
-        }
-
-        // Clean up ComPtr/IUnknown objects
-        if (audioController)
-        {
-            if (mainAudioEndpoint)
-            {
-                mainAudioEndpoint->VolumeChanged(mainAudioEndpointVolumeChangedToken);
-                mainAudioEndpoint->Unregister();
-                mainAudioEndpoint->Release();
-            }
-
-            audioController->EndpointChanged(audioControllerEndpointChangedToken);
-            audioController->SessionAdded(audioControllerSessionAddedToken);
-
-            assert(audioController->Unregister());
-            assert(audioController->Release() == 0);
-        }
-
-        if (forReload)
-        {
-            audioSessionViews.Clear();
-        }
-        else
-        {
-            SaveAudioLevels();
-        }
-    }
-
-    // TODO: Rename to DrawSizeIndicators
-    void MainWindow::SetSizeIndicators()
-    {
-        if (layout != 2)
-        {
-            double gridHeight = ContentGrid().ActualHeight();
-            double gridWidth = ContentGrid().ActualWidth();
-
-            RootCanvas().Children().Clear();
-
-            int32_t position = 1;
-            const int32_t sessionHeight = 290 + 2;
-            while ((position * sessionHeight) < gridHeight)
-            {
-                winrt::Microsoft::UI::Xaml::Shapes::Rectangle rect{};
-                rect.Width(6);
-                rect.Height(1);
-                auto&& brush = Xaml::SolidColorBrush(UI::Colors::DimGray());
-                brush.Opacity(0.5);
-                rect.Fill(brush);
-
-                Xaml::Canvas::SetLeft(rect, 0);
-                Xaml::Canvas::SetTop(rect, position * sessionHeight);
-                RootCanvas().Children().Append(rect);
-
-                position++;
-            }
-
-            position = 1;
-            const int32_t sessionWidth = 80 + 3;
-            while ((position * sessionWidth) < gridWidth)
-            {
-                winrt::Microsoft::UI::Xaml::Shapes::Rectangle rect{};
-                rect.Width(1);
-                rect.Height(6);
-                auto&& brush = Xaml::SolidColorBrush(UI::Colors::DimGray());
-                brush.Opacity(0.5);
-                rect.Fill(brush);
-
-                Xaml::Canvas::SetLeft(rect, position * sessionWidth);
-                Xaml::Canvas::SetTop(rect, 0);
-                RootCanvas().Children().Append(rect);
-
-                position++;
-            }
-        }
-    }
-
-    void MainWindow::UpdatePeakMeters(Foundation::IInspectable, Foundation::IInspectable)
-    {
-        if (!loaded || audioSessions.size() == 0) return;
-
-        for (auto const& view : audioSessionViews)
-        {
-            auto&& pair = audioSessions.at(view.Id())->GetChannelsPeak();
-            view.SetPeak(pair.first, pair.second);
+            DebugBreak();
         }
     }
 
     void MainWindow::AppWindow_Closing(UI::AppWindow, UI::AppWindowClosingEventArgs)
     {
-        SaveSettings();
-        CleanUpResources(false);
-    }
-
-    void MainWindow::MainAudioEndpoint_VolumeChanged(IInspectable, const float& newVolume)
-    {
-        if (!loaded) return;
-
-        DispatcherQueue().TryEnqueue([this, newVolume]()
+        bool failed = false;
+        try
         {
-            SystemVolumeSlider().Value(newVolume * 100.);
-        });
-    }
-
-    void MainWindow::AudioSession_VolumeChanged(const winrt::guid& id, const float& newVolume)
-    {
-        if (!loaded) return;
-
-        DispatcherQueue().TryEnqueue([this, id, newVolume]()
-        {
-            for (auto const& view : audioSessionViews)
-            {
-                if (view.Id() == id)
-                {
-                    view.Volume(static_cast<double>(newVolume) * 100.0);
-                }
-            }
-        });
-    }
-
-    void MainWindow::AudioSession_StateChanged(const winrt::guid& id, const uint32_t& state)
-    {
-        if (!loaded) return;
-
-        // Cast state to AudioSessionState, uint32_t is only used to cross ABI
-        AudioSessionState audioState = (AudioSessionState)state;
-        if (audioState == AudioSessionState::Expired || audioState == AudioSessionState::Active)
-        {
-            audioSessionsPeakTimer.Stop();
-
-            std::unique_lock lock{ audioSessionsMutex };
-
-            if (audioSessions.contains(id))
-            {
-                if (audioState == AudioSessionState::Active)
-                {
-                    // Check if the newly active session is added to the UI, if not I need to add it as it might been skipped because of grouping params and the session being inactive at the time.
-                    bool added = false;
-                    for (auto const& view : audioSessionViews)
-                    {
-                        if (view.Id() == id)
-                        {
-                            added = true;
-                            break;
-                        }
-                    }
-
-                    if (!added)
-                    {
-                        lock.unlock();
-
-                        DispatcherQueue().TryEnqueue([this, id]()
-                        {
-                            std::unique_lock lock{ audioSessionsMutex };
-
-                            if (AudioSessionView view = CreateAudioSessionView(audioSessions.at(id), true))
-                            {
-                                audioSessionViews.InsertAt(0, view);
-                            }
-                        });
-
-                        // The function exists here since the code in DispatcherQueue().TryEnqueue() relies on finding an AudioSessionView with the matching id. Or I found that the AudioSessionView with the given id does not exists.
-                        audioSessionsPeakTimer.Start();
-                        return;
-                    }
-                }
-                else
-                {
-                    // The audio session is expired 
-                    CAudio::AudioSession* session = audioSessions.at(id);
-                    session->VolumeChanged(audioSessionVolumeChanged[session->Id()]);
-                    session->StateChanged(audioSessionsStateChanged[session->Id()]);
-                    assert(session->Unregister());
-                    session->Release();
-
-                    audioSessions.erase(id);
-                }
-            }
-
-            audioSessionsPeakTimer.Start();
+            SaveSettings();
         }
-
-        DispatcherQueue().TryEnqueue([this, id, audioState]()
+        catch (...)
         {
-            for (auto const& view : audioSessionViews)
-            {
-                if (view.Id() == id)
-                {
-                    switch (audioState)
-                    {
-                        case AudioSessionState::Muted:
-                            view.Muted(true);
-                            break;
-
-                        case AudioSessionState::Unmuted:
-                            view.Muted(false);
-                            break;
-
-                        case AudioSessionState::Active:
-                        case AudioSessionState::Inactive:
-                            view.SetState(audioState);
-                            break;
-
-                        case AudioSessionState::Expired:
-                            uint32_t indexOf = 0;
-                            if (audioSessionViews.IndexOf(view, indexOf))
-                            {
-                                audioSessionViews.RemoveAt(indexOf);
-
-                                if (audioSessionViews.Size() == 0)
-                                {
-                                    WindowMessageBar().EnqueueString(L"All sessions expired.");
-                                }
-                            }
-                            break;
-                    }
-
-                    return;
-                }
-            }
-        });
-    }
-
-    void MainWindow::AudioController_SessionAdded(Foundation::IInspectable, Foundation::IInspectable)
-    {
-        // TODO: Reorder audio sessions according to the currently loaded audio profile (if any).
-        DispatcherQueue().TryEnqueue([this]()
-        {
-            audioSessionsPeakTimer.Stop();
-
-            while (CAudio::AudioSession* newSession = audioController->NewSession())
-            {
-                {
-                    std::unique_lock lock{ audioSessionsMutex };
-                    audioSessions.insert({ newSession->Id(), newSession });
-                }
-
-                if (AudioSessionView view = CreateAudioView(newSession))
-                {
-                    // TODO: If a profile is loaded, find the right index for the audio session to be added to.
-                    audioSessionViews.InsertAt(0, view);
-                }
-            }
-
-            audioSessionsPeakTimer.Start();
-        });
-    }
-
-    void MainWindow::AudioController_EndpointChanged(Foundation::IInspectable, Foundation::IInspectable)
-    {
-        // Stop animation while getting the new audio endpoint.
-        mainAudioEndpointPeakTimer.Stop();
-
-        mainAudioEndpoint->VolumeChanged(mainAudioEndpointVolumeChangedToken);
-        mainAudioEndpoint->StateChanged(mainAudioEndpointStateChangedToken);
-        mainAudioEndpoint->Unregister();
-        mainAudioEndpoint->Release();
-
-        mainAudioEndpoint = audioController->GetMainAudioEndpoint();
-        if (mainAudioEndpoint->Register())
-        {
-            // Register to events.
-            mainAudioEndpointVolumeChangedToken = mainAudioEndpoint->VolumeChanged({ this, &MainWindow::MainAudioEndpoint_VolumeChanged });
-            mainAudioEndpointStateChangedToken = mainAudioEndpoint->StateChanged([this](IInspectable, bool muted)
-            {
-                DispatcherQueue().TryEnqueue([this, muted]()
-                {
-                    MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
-                    MuteToggleButtonFontIcon().Glyph(muted ? L"\ue74f" : L"\ue767");
-                });
-            });
+            failed = true;
+            AudioViewer().CloseAudioObjects();
+            throw;
         }
-
-
-        DispatcherQueue().TryEnqueue([&]()
+        
+        if (!failed)
         {
-            mainAudioEndpointPeakTimer.Start();
-
-            MainEndpointNameTextBlock().Text(mainAudioEndpoint->Name());
-            SystemVolumeSlider().Value(static_cast<double>(mainAudioEndpoint->Volume()) * 100.);
-            MuteToggleButton().IsChecked(mainAudioEndpoint->Muted());
-
-            ReloadAudioSessions();
-        });
+            AudioViewer().CloseAudioObjects();
+        }
     }
 
     void MainWindow::HotKeyFired(const uint32_t& id, const Foundation::IInspectable&)
@@ -2069,84 +964,53 @@ namespace winrt::Croak::implementation
         constexpr float stepping = 0.01f;
         constexpr float largeStepping = 0.07f;
 
-        try
+        if (id == MOVE_WINDOW || id == MOVE_WINDOW_ALT)
         {
-            switch (id)
+            if (windowActivated)
             {
-                case VOLUME_DOWN:
+                if (unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"HideWindowInOverlayMode"), false))
                 {
-                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() - stepping > 0.f ? mainAudioEndpoint->Volume() - stepping : 0.f);
-                    break;
+                    appWindow.Hide();
                 }
-                case VOLUME_UP:
+                else
                 {
-                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() + stepping < 1.f ? mainAudioEndpoint->Volume() + stepping : 1.f);
-                    break;
+                    appWindow.Presenter().as<UI::OverlappedPresenter>().Minimize();
                 }
-                case VOLUME_UP_ALT:
+            }
+            else
+            {
+                POINT p{};
+                if (GetCursorPos(&p))
                 {
-                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() + largeStepping < 1.f ? mainAudioEndpoint->Volume() + largeStepping : 1.f);
-                    break;
-                }
-                case VOLUME_DOWN_ALT:
-                {
-                    mainAudioEndpoint->SetVolume(mainAudioEndpoint->Volume() - largeStepping > 0.f ? mainAudioEndpoint->Volume() - largeStepping : 0.f);
-                    break;
-                }
-                case MUTE_SYSTEM:
-                {
-                    mainAudioEndpoint->SetMute(!mainAudioEndpoint->Muted());
+                    UI::DisplayArea currentDisplay = UI::DisplayArea::GetFromPoint(Graphics::PointInt32(p.x, p.y), UI::DisplayAreaFallback::None);
+                    auto windowPos = Graphics::PointInt32(displayRect.X, displayRect.Y);
+                    UI::DisplayArea windowDisplay = UI::DisplayArea::GetFromPoint(windowPos, UI::DisplayAreaFallback::None);
 
-                    DispatcherQueue().TryEnqueue([this]()
+                    Graphics::PointInt32 newPos
                     {
-                        MuteToggleButtonFontIcon().Glyph(mainAudioEndpoint->Muted() ? L"\ue74f" : L"\ue767");
-                        MuteToggleButton().IsChecked(Foundation::IReference(mainAudioEndpoint->Muted()));
-                    });
-                    break;
-                }
-                case MOVE_WINDOW:
-                {
-                    POINT p{};
-                    if (GetCursorPos(&p))
+                        currentDisplay.WorkArea().X + (windowPos.X - windowDisplay.WorkArea().X),
+                        currentDisplay.WorkArea().Y + (windowPos.Y - windowDisplay.WorkArea().Y)
+                    };
+
+                    if (UI::DisplayArea::GetFromPoint(newPos, UI::DisplayAreaFallback::None))
                     {
-                        UI::DisplayArea currentDisplay = UI::DisplayArea::GetFromPoint(Graphics::PointInt32(p.x, p.y), UI::DisplayAreaFallback::None);
-                        auto windowPos = Graphics::PointInt32(displayRect.X, displayRect.Y);
-                        UI::DisplayArea windowDisplay = UI::DisplayArea::GetFromPoint(windowPos, UI::DisplayAreaFallback::None);
+                        appWindow.Move(newPos);
+                        appWindow.Show();
 
-                        Graphics::PointInt32 newPos
-                        { 
-                            currentDisplay.WorkArea().X + (windowPos.X - windowDisplay.WorkArea().X),
-                            currentDisplay.WorkArea().Y + (windowPos.Y - windowDisplay.WorkArea().Y)
-                        };
-
-                        if (UI::DisplayArea::GetFromPoint(newPos, UI::DisplayAreaFallback::None))
+                        auto nativeWindow{ this->try_as<::IWindowNative>() };
+                        if (nativeWindow)
                         {
-                            appWindow.Move(newPos);
-                            if (!appWindow.IsVisible())
-                            {
-                                appWindow.Show();
-                            }
-
-                            auto nativeWindow{ this->try_as<::IWindowNative>() };
-                            if (nativeWindow)
-                            {
-                                HWND handle = nullptr;
-                                nativeWindow->get_WindowHandle(&handle);
-                                SwitchToThisWindow(handle, true);
-                            }
+                            HWND handle = nullptr;
+                            nativeWindow->get_WindowHandle(&handle);
+                            SwitchToThisWindow(handle, true);
                         }
                     }
-                    break;
-                }
-                default:
-                {
-                    DebugLog(std::format("Hot key not recognized. Id: {0}", id));
                 }
             }
         }
-        catch (...)
+        else
         {
+            DebugLog(std::format("Hot key not recognized. Id: {0}", id));
         }
     }
-
 }

--- a/Croak/MainWindow.xaml.h
+++ b/Croak/MainWindow.xaml.h
@@ -19,11 +19,6 @@ namespace winrt::Croak::implementation
             return singleton;
         }
 
-        inline winrt::Windows::Foundation::Collections::IObservableVector<winrt::Croak::AudioSessionView> AudioSessions() const
-        {
-            return audioSessionViews;
-        }
-
         inline winrt::Windows::Graphics::RectInt32 DisplayRect()
         {
             if (appWindow)
@@ -40,13 +35,9 @@ namespace winrt::Croak::implementation
 
 #pragma region Events
         void OnLoaded(winrt::Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& e);
-        void AudioSessionView_VolumeChanged(winrt::Croak::AudioSessionView const& sender, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& args);
-        void AudioSessionView_VolumeStateChanged(winrt::Croak::AudioSessionView const& sender, bool const& args);
-        void AudioSessionsPanel_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
+        void OnLoading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
         void Grid_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& e);
-        void SystemVolumeSlider_ValueChanged(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs const& e);
         void Window_Activated(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowActivatedEventArgs const& args);
-        void SystemVolumeActivityBorder_SizeChanged(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const&);
         void HideMenuFlyoutItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void SwitchStateMenuFlyoutItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void HorizontalViewMenuFlyoutItem_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
@@ -71,7 +62,6 @@ namespace winrt::Croak::implementation
         void OverlayModeToggleButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
 #pragma endregion
 
-
     private:
         using BackdropController = winrt::Microsoft::UI::Composition::SystemBackdrops::DesktopAcrylicController;
 
@@ -79,23 +69,10 @@ namespace winrt::Croak::implementation
         static winrt::Croak::MainWindow singleton;
 
         // Logic related attributes.
-        std::mutex audioSessionsMutex{};
-        std::mutex mainAudioEndpointMutex{};
-        ::Croak::Audio::DefaultAudioEndpoint* mainAudioEndpoint = nullptr;
-        ::Croak::Audio::AudioController* audioController = nullptr;
-        std::map<winrt::guid, ::Croak::Audio::AudioSession*> audioSessions{};
-        winrt::event_token mainAudioEndpointVolumeChangedToken;
-        winrt::event_token mainAudioEndpointStateChangedToken;
-        winrt::event_token audioControllerSessionAddedToken;
-        winrt::event_token audioControllerEndpointChangedToken;
-        std::map<winrt::guid, winrt::event_token> audioSessionVolumeChanged{};
-        std::map<winrt::guid, winrt::event_token> audioSessionsStateChanged{};
         // UI related attributes.
         bool loaded = false;
         bool compact = false;
         bool usingCustomTitleBar = false;
-        uint16_t layout = 0;
-        winrt::Croak::AudioSessionState globalSessionAudioState = winrt::Croak::AudioSessionState::Unmuted;
         winrt::Windows::Graphics::RectInt32 displayRect;
         winrt::Microsoft::UI::Windowing::AppWindow appWindow = nullptr;
 #pragma region Backdrop
@@ -103,41 +80,26 @@ namespace winrt::Croak::implementation
         winrt::Windows::System::DispatcherQueueController dispatcherQueueController = nullptr;
         winrt::Microsoft::UI::Composition::SystemBackdrops::SystemBackdropConfiguration systemBackdropConfiguration = nullptr;
         winrt::Microsoft::UI::Xaml::FrameworkElement::ActualThemeChanged_revoker themeChangedRevoker;
-        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer audioSessionsPeakTimer = nullptr;
-        winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer mainAudioEndpointPeakTimer = nullptr;
 #pragma endregion
-        winrt::Windows::Foundation::Collections::IObservableVector<winrt::Croak::AudioSessionView> audioSessionViews
-        {
-            winrt::multi_threaded_observable_vector<winrt::Croak::AudioSessionView>()
-        };
         winrt::Croak::SecondWindow secondWindow{ nullptr };
-        winrt::Croak::AudioProfile currentAudioProfile{ nullptr };
+        winrt::Croak::UserProfile currentProfile{ nullptr };
+        bool hotKeysEnabled = true;
+        bool windowActivated = false;
+        winrt::Windows::ApplicationModel::Resources::ResourceLoader resourceLoader{};
 
         void InitializeWindow();
         void SetBackground();
         void LoadContent();
-        winrt::Croak::AudioSessionView CreateAudioView(::Croak::Audio::AudioSession* audioSession);
-        winrt::Croak::AudioSessionView CreateAudioSessionView(::Croak::Audio::AudioSession* audioSession, bool skipDuplicates);
         void SetDragRectangles();
-        void SaveAudioLevels();
         void LoadHotKeys();
-        void LoadSettings();
+        void LoadSettings(const winrt::Croak::UserProfile& profile);
         void SaveSettings();
-        void LoadAudioProfile(const hstring& profileName);
-        void ReloadAudioSessions();
-        std::map<winrt::guid, ::Croak::Audio::AudioSession*> MapAudioSessions(std::vector<::Croak::Audio::AudioSession*>* vect);
-        void CleanUpResources(const bool& forReload);
-        void InsertSessionAccordingToProfile(::Croak::Audio::AudioSession* audioSession);
-        void SetSizeIndicators();
+        void LoadProfileByName(const hstring& profileName);
+        winrt::Croak::UserProfile LoadStartupProfile();
+        winrt::Croak::UserProfile CreateDefaultProfile();
 
         void HotKeyFired(const uint32_t& id, const Windows::Foundation::IInspectable& /*args*/);
         void AppWindow_Closing(winrt::Microsoft::UI::Windowing::AppWindow, winrt::Microsoft::UI::Windowing::AppWindowClosingEventArgs);
-        void UpdatePeakMeters(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
-        void MainAudioEndpoint_VolumeChanged(winrt::Windows::Foundation::IInspectable /*sender*/, const float& newVolume);
-        void AudioSession_VolumeChanged(const winrt::guid& sender, const float& newVolume);
-        void AudioSession_StateChanged(const winrt::guid& sender, const uint32_t& state);
-        void AudioController_SessionAdded(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
-        void AudioController_EndpointChanged(winrt::Windows::Foundation::IInspectable /*sender*/, winrt::Windows::Foundation::IInspectable /*args*/);
     };
 }
 

--- a/Croak/MessageBar.xaml
+++ b/Croak/MessageBar.xaml
@@ -6,27 +6,28 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    Background="{StaticResource MessageBarDefaultBackgroundBrush}"
+    BorderBrush="{ThemeResource AccentControlElevationBorderBrush}"
+    CornerRadius="{StaticResource ControlCornerRadius}"
+    BackgroundSizing="OuterBorderEdge"
+    VerticalAlignment="Top"
+    HorizontalAlignment="Stretch"
     Loaded="UserControl_Loaded"
-    HorizontalAlignment="Stretch">
+    Loading="MessageControl_Loading">
 
     <Grid
         x:Name="RootGrid"
         Padding="5"
         ColumnSpacing="5"
-        CornerRadius="{StaticResource ControlCornerRadius}"
-        BorderBrush="{ThemeResource AccentControlElevationBorderBrush}"
+        VerticalAlignment="Stretch"
+        HorizontalAlignment="Stretch"
+        CornerRadius="{x:Bind CornerRadius, Mode=OneWay}"
+        BorderBrush="{x:Bind BorderBrush, Mode=OneWay}"
+        Background="{x:Bind Background, Mode=OneWay}"
         MinHeight="55">
         <Grid.RenderTransform>
             <CompositeTransform />
         </Grid.RenderTransform>
-        <Grid.Background>
-            <AcrylicBrush
-                FallbackColor="{ThemeResource SolidBackgroundFillColorTertiary}"
-                TintColor="{ThemeResource SystemAccentColorDark3}"
-                TintOpacity="0.55"
-                TintLuminosityOpacity="0.5"
-                Opacity="1"/>
-        </Grid.Background>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -40,13 +41,11 @@
                         <Setter Target="MessageControl.Visibility" Value="Visible" />
                     </VisualState.Setters>
 
-                    <Storyboard>
+                    <Storyboard x:Name="VisibleStateStoryboard">
                         <DoubleAnimationUsingKeyFrames 
+                            x:Name="AppearAnimation"
                             Storyboard.TargetName="RootGrid" 
-                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.ScaleY)">
-
-                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0" />
-                            <SplineDoubleKeyFrame KeyTime="0:0:0.167" Value="1" KeySpline="0.0, 0.0, 0.0, 1.0" />
+                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
                         </DoubleAnimationUsingKeyFrames>
 
                         <DoubleAnimation
@@ -63,14 +62,12 @@
                 </VisualState>
 
                 <VisualState x:Name="Collapsed">
-                    <Storyboard>
+                    <Storyboard x:Name="CollapsedStateStoryboard">
                         <DoubleAnimationUsingKeyFrames 
+                            x:Name="DisappearAnimation"
                             Storyboard.TargetName="RootGrid" 
-                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.ScaleY)">
-
-                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
-                            <SplineDoubleKeyFrame KeyTime="0:0:0.167" Value="0" KeySpline="1.0, 1.0, 0.0, 1.0" />
-                        </DoubleAnimationUsingKeyFrames>
+                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateY)">
+                        </DoubleAnimationUsingKeyFrames>    
 
                         <DoubleAnimation
                             Storyboard.TargetName="RootGrid"

--- a/Croak/MessageBar.xaml.h
+++ b/Croak/MessageBar.xaml.h
@@ -20,12 +20,14 @@ namespace winrt::Croak::implementation
         void CloseButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void UserControl_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void TimerProgressBar_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& e);
+        void MessageControl_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
 
     private:
         std::mutex messageQueueMutex{};
         std::queue<winrt::Windows::Foundation::IInspectable> messageQueue{};
         winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer timer = nullptr;
 
+        void InitializeAnimations();
         void DisplayMessage();
 
         void DispatcherQueueTimer_Tick(winrt::Microsoft::UI::Dispatching::DispatcherQueueTimer, winrt::Windows::Foundation::IInspectable);

--- a/Croak/OverlaySettingsPage.xaml
+++ b/Croak/OverlaySettingsPage.xaml
@@ -21,7 +21,7 @@
                 Margin="20,0,20,0"
                 Width="1920"
                 Height="1080"
-                Background="{ThemeResource SolidBackgroundFillColorSecondary}"
+                Background="{ThemeResource SolidBackgroundFillColorBaseAlt}"
                 PointerPressed="Canvas_PointerPressed"
                 PointerReleased="Canvas_PointerReleased"
                 PointerEntered="DisplayCanvas_PointerEntered"

--- a/Croak/OverlaySettingsPage.xaml.cpp
+++ b/Croak/OverlaySettingsPage.xaml.cpp
@@ -9,7 +9,11 @@
 namespace Foundation = winrt::Windows::Foundation;
 namespace Input = winrt::Microsoft::UI::Input;
 namespace UI = winrt::Windows::UI;
-namespace Storage = winrt::Windows::Storage;
+namespace Storage
+{
+    using namespace winrt::Windows::Storage;
+    using namespace winrt::Windows::ApplicationModel::Resources;
+}
 namespace Xaml
 {
     using namespace winrt::Microsoft::UI::Xaml;
@@ -25,6 +29,28 @@ namespace winrt::Croak::implementation
     {
         InitializeComponent();
     }
+
+    void OverlaySettingsPage::OnNavigatedTo(const winrt::Microsoft::UI::Xaml::Navigation::NavigationEventArgs& args)
+    {
+        if (args.NavigationMode() == Xaml::Navigation::NavigationMode::New)
+        {
+            if (SecondWindow::Current().Breadcrumbs().Size() > 0)
+            {
+                auto atEnd = SecondWindow::Current().Breadcrumbs().GetAt(SecondWindow::Current().Breadcrumbs().Size() - 1);
+                if (atEnd.ItemTypeName() != xaml_typename<winrt::Croak::OverlaySettingsPage>())
+                {
+                    Storage::ResourceLoader resLoader{};
+                    SecondWindow::Current().Breadcrumbs().Append(NavigationBreadcrumbBarItem(resLoader.GetString(L"OverlaySettingsPageName"), xaml_typename<winrt::Croak::OverlaySettingsPage>()));
+                }
+            }
+            else
+            {
+                Storage::ResourceLoader resLoader{};
+                SecondWindow::Current().Breadcrumbs().Append(NavigationBreadcrumbBarItem(resLoader.GetString(L"OverlaySettingsPageName"), xaml_typename< winrt::Croak::OverlaySettingsPage >()));
+            }
+        }
+    }
+
 
     void OverlaySettingsPage::Page_Loaded(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
     {

--- a/Croak/OverlaySettingsPage.xaml.h
+++ b/Croak/OverlaySettingsPage.xaml.h
@@ -9,6 +9,8 @@ namespace winrt::Croak::implementation
     public:
         OverlaySettingsPage();
 
+        void OnNavigatedTo(const winrt::Microsoft::UI::Xaml::Navigation::NavigationEventArgs& args);
+
         void Canvas_PointerPressed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void DisplayCanvas_PointerMoved(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::PointerRoutedEventArgs const& e);
         void Page_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);

--- a/Croak/Package.appxmanifest
+++ b/Croak/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="751c2636-5688-4a5f-9a67-e04d5b64d3d3"
     Publisher="CN=psyKomicron"
-    Version="1.2.0.0" />
+    Version="1.2.1.0" />
 
   <Properties>
     <DisplayName>Croak</DisplayName>

--- a/Croak/Resources.lang-en-us.resw
+++ b/Croak/Resources.lang-en-us.resw
@@ -138,6 +138,9 @@
   <data name="AudioSessionViewLockMenuFlyoutItem.Text" xml:space="preserve">
     <value>Lock</value>
   </data>
+  <data name="DefaultProfileName" xml:space="preserve">
+    <value>Default profile</value>
+  </data>
   <data name="ErrorAppFailedRestart" xml:space="preserve">
     <value>Failed to restart app, try again or close the window</value>
   </data>
@@ -148,10 +151,10 @@
     <value>Oh oh, something went wrong... Please restart the app and try again.</value>
   </data>
   <data name="ErrorLoadingAudioObjects" xml:space="preserve">
-    <value />
+    <value>Error loading audio objects</value>
   </data>
   <data name="ErrorUuidCreateFailed" xml:space="preserve">
-    <value />
+    <value>Error UUID creation failed</value>
   </data>
   <data name="HotKeyName.1" xml:space="preserve">
     <value>System volume up</value>
@@ -169,7 +172,10 @@
     <value>Mute volume</value>
   </data>
   <data name="HotKeyName.6" xml:space="preserve">
-    <value>Bring to screen</value>
+    <value>Bring to foreground/Show window</value>
+  </data>
+  <data name="HotKeyName.7" xml:space="preserve">
+    <value>Bring to foreground/Show window (Alt)</value>
   </data>
   <data name="HotKeysPageDisplayName" xml:space="preserve">
     <value>Hot keys</value>
@@ -182,6 +188,9 @@
   </data>
   <data name="InfoHotKeysEnabled" xml:space="preserve">
     <value>Hot keys enabled</value>
+  </data>
+  <data name="LoadProfileFailed" xml:space="preserve">
+    <value>Failed to load profile</value>
   </data>
   <data name="MainWindowDisableAnimationsButton.Content" xml:space="preserve">
     <value>Disable animations</value>
@@ -250,7 +259,10 @@
     <value>What's new</value>
   </data>
   <data name="OverlayModeEnabled" xml:space="preserve">
-    <value>Overlay mode activated</value>
+    <value>Overlay mode activated, use Alt + A to show window</value>
+  </data>
+  <data name="OverlaySettingsPageName" xml:space="preserve">
+    <value>Overlay</value>
   </data>
   <data name="SecondWindowTitle" xml:space="preserve">
     <value>Croak settings</value>

--- a/Croak/Resources.lang-fr-fr.resw
+++ b/Croak/Resources.lang-fr-fr.resw
@@ -138,6 +138,9 @@
   <data name="AudioSessionViewLockMenuFlyoutItem.Text" xml:space="preserve">
     <value>Verrouiller</value>
   </data>
+  <data name="DefaultProfileName" xml:space="preserve">
+    <value>Profile par défaut</value>
+  </data>
   <data name="ErrorAppFailedRestart" xml:space="preserve">
     <value>L'application n'a pas pu être redémarrée</value>
   </data>
@@ -148,10 +151,10 @@
     <value>Oh oh... Une erreur est survenue, essayez de redémarrer l'application</value>
   </data>
   <data name="ErrorLoadingAudioObjects" xml:space="preserve">
-    <value>Un problème est survenu, pas d'audio</value>
+    <value>Un problème est survenu, pas possible de charger les périphériques audio</value>
   </data>
   <data name="ErrorUuidCreateFailed" xml:space="preserve">
-    <value />
+    <value>Error UUID creation failed (en francais)</value>
   </data>
   <data name="HotKeyName.1" xml:space="preserve">
     <value>Augmenter le volume système</value>
@@ -169,7 +172,10 @@
     <value>Couper le son</value>
   </data>
   <data name="HotKeyName.6" xml:space="preserve">
-    <value>Bring to screen</value>
+    <value>Bring to foreground/Show window</value>
+  </data>
+  <data name="HotKeyName.7" xml:space="preserve">
+    <value>Bring to foreground/Show window (Alt)</value>
   </data>
   <data name="HotKeysPageDisplayName" xml:space="preserve">
     <value>Hot keys</value>
@@ -182,6 +188,9 @@
   </data>
   <data name="InfoHotKeysEnabled" xml:space="preserve">
     <value>Hot keys activées</value>
+  </data>
+  <data name="LoadProfileFailed" xml:space="preserve">
+    <value>Pas possible de charger le profile</value>
   </data>
   <data name="MainWindowDisableAnimationsButton.Content" xml:space="preserve">
     <value>Désactiver les animations</value>
@@ -250,7 +259,10 @@
     <value>Nouveautées</value>
   </data>
   <data name="OverlayModeEnabled" xml:space="preserve">
-    <value>Mode overlay activé</value>
+    <value>Mode overlay activé, appuyez sur Alt + A pour montrer l'application</value>
+  </data>
+  <data name="OverlaySettingsPageName" xml:space="preserve">
+    <value>Mode superposé</value>
   </data>
   <data name="SecondWindowTitle" xml:space="preserve">
     <value>Paramètres (Croak)</value>

--- a/Croak/SettingsPage.xaml.cpp
+++ b/Croak/SettingsPage.xaml.cpp
@@ -27,6 +27,18 @@ namespace winrt::Croak::implementation
         );
     }
 
+    void SettingsPage::OnNavigatedTo(Xaml::NavigationEventArgs const& args)
+    {
+        if (args.NavigationMode() == Xaml::NavigationMode::New || SecondWindow::Current().Breadcrumbs().Size() == 0)
+        {
+            winrt::Windows::ApplicationModel::Resources::ResourceLoader loader{};
+            SecondWindow::Current().Breadcrumbs().Append(
+                NavigationBreadcrumbBarItem{ loader.GetString(L"SettingsPageDisplayName"), xaml_typename<winrt::Croak::SettingsPage>() }
+            );
+        }
+    }
+
+
     Foundation::IAsyncAction SettingsPage::Page_Loaded(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)
     {
         ApplicationModel::StartupTask startupTask = co_await ApplicationModel::StartupTask::GetAsync(L"CroakStartupTaskId");
@@ -36,17 +48,6 @@ namespace winrt::Croak::implementation
         PowerEfficiencyToggleButton().IsOn(unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"PowerEfficiencyEnabled"), true));
         StartupProfileToggleSwitch().IsOn(unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"LoadLastProfile"), true));
         HideWindowToggleSwitch().IsOn(unbox_value_or(Storage::ApplicationData::Current().LocalSettings().Values().TryLookup(L"HideWindowOnCompactMode"), false));
-    }
-
-    void SettingsPage::OnNavigatedTo(Xaml::NavigationEventArgs const& args)
-    {
-        if (args.NavigationMode() == Xaml::NavigationMode::New)
-        {
-            winrt::Windows::ApplicationModel::Resources::ResourceLoader loader{};
-            SecondWindow::Current().Breadcrumbs().Append(
-                NavigationBreadcrumbBarItem{ loader.GetString(L"SettingsPageDisplayName"), xaml_typename<winrt::Croak::SettingsPage>() }
-            );
-        }
     }
 
     void SettingsPage::AudioProfilesButton_Click(Foundation::IInspectable const&, Xaml::RoutedEventArgs const&)

--- a/Croak/Themes/Generic.xaml
+++ b/Croak/Themes/Generic.xaml
@@ -29,6 +29,14 @@
         </GradientStopCollection>
     </LinearGradientBrush>
 
+    <AcrylicBrush
+        x:Key="MessageBarDefaultBackgroundBrush"
+        FallbackColor="{ThemeResource SystemAccentColorDark3}"
+        TintColor="{ThemeResource SystemAccentColorDark3}"
+        TintOpacity="0.55"
+        TintLuminosityOpacity="0.5"
+        Opacity="1"/>
+
     <Color x:Key="WindowsLogoColor">#5FDFFF</Color>
 
     <Thickness x:Key="ToggleSwitchCenterMargin">0,0,-20,0</Thickness>
@@ -45,7 +53,7 @@
     <x:Double x:Key="AudioSessionViewMaxHeight">290</x:Double>
     <x:Double x:Key="FontIconHeight">16</x:Double>
     <x:Double x:Key="SettingHostControlMinHeight">70</x:Double>
-    <x:Double x:Key="PeakBorderOpacity">0.55</x:Double>
+    <x:Double x:Key="PeakBorderOpacity">0.75</x:Double>
 
     <x:Int32 x:Key="WindowWidth">400</x:Int32>
     <x:Int32 x:Key="WindowHeight">500</x:Int32>
@@ -1751,7 +1759,8 @@
     </Style>
 
     <Style TargetType="local:IconToggleButton" >
-        <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
+        <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+        <Setter Property="Background" Value="{ThemeResource ToggleButtonBackgroundThemeBrush}"/>
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
@@ -1782,29 +1791,65 @@
                         </Grid.BackgroundTransition>
 
                         <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
+                            <VisualStateGroup x:Name="PointerStates">
                                 <VisualState x:Name="Normal" />
 
-                                <VisualState x:Name="PointerOver">
-
+                                <VisualState x:Name="Checked">
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBackgroundChecked}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrushChecked}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OffIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OnIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Icon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="PointerOver">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBackgroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrushPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OffIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OnIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Icon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimaryBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
                                 <VisualState x:Name="PointerPressed">
-
                                     <Storyboard>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -1821,47 +1866,130 @@
                                     </Storyboard>
                                 </VisualState>
 
-                            </VisualStateGroup>
-
-                            <VisualStateGroup x:Name="PresenterStates">
-
-                                <VisualState x:Name="Off">
+                                <VisualState x:Name="PointerOverChecked">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBackgroundCheckedPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrushCheckedPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OffIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OnIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Icon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
                                 </VisualState>
 
-                                <VisualState x:Name="On">
+                                <VisualState x:Name="PointerPressedChecked">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBackgroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrushCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OffIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OnIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Icon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="DisabledChecked">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBackgroundCheckedDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrushCheckedDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OffIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="OnIcon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Icon" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="IconStates">
+                                <VisualState x:Name="UseDefaultIcon"/>
+
+                                <VisualState x:Name="ShowOnIcon">
+                                    <VisualState.Setters>
+                                        <Setter Target="Icon.Visibility" Value="Collapsed"/>
+                                        <Setter Target="OffIcon.Visibility" Value="Collapsed"/>
+                                        <Setter Target="OnIcon.Visibility" Value="Visible"/>
+                                    </VisualState.Setters>                                    
+                                </VisualState>
+
+                                <VisualState x:Name="ShowOffIcon">
+                                    <VisualState.Setters>
+                                        <Setter Target="Icon.Visibility" Value="Collapsed"/>
+                                        <Setter Target="OnIcon.Visibility" Value="Collapsed"/>
+                                        <Setter Target="OffIcon.Visibility" Value="Visible"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
                         </VisualStateManager.VisualStateGroups>
 
-                        <FontIcon 
+                        <FontIcon
                             x:Name="Icon" 
                             Grid.Column="0" 
                             FontSize="14" 
+                            VerticalAlignment="Center"
                             Glyph="{TemplateBinding Glyph}" />
-                        <FontIcon 
+                        <ContentPresenter
                             x:Name="OnIcon" 
                             Grid.Column="0" 
                             FontSize="14" 
-                            Glyph="{TemplateBinding OnIcon}" 
+                            Content="{TemplateBinding OnIcon}" 
+                            FontFamily="{StaticResource SymbolThemeFontFamily}"
+                            VerticalAlignment="Center"
                             Visibility="Collapsed" />
-                        <FontIcon 
+                        <ContentPresenter                             
                             x:Name="OffIcon" 
+                            FontFamily="{StaticResource SymbolThemeFontFamily}"
                             Grid.Column="0" 
                             FontSize="14" 
-                            Glyph="{TemplateBinding OffIcon}" 
+                            Content="{TemplateBinding OffIcon}" 
+                            VerticalAlignment="Center"
                             Visibility="Collapsed" />
 
                         <ContentPresenter 
                             x:Name="ContentPresenter"
-                            Content="{TemplateBinding Content}" 
+                            Content="{TemplateBinding Content}"
+                            Foreground="{TemplateBinding Foreground}"
                             Grid.Column="1" 
                             Opacity="1" 
                             TextWrapping="Wrap"
-                            HorizontalAlignment="Stretch">
-                            <ContentPresenter.OpacityTransition>
-                                <ScalarTransition Duration="0:0:0.167" />
-                            </ContentPresenter.OpacityTransition>
-                        </ContentPresenter>
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Stretch"/>
                     </Grid>
 
                 </ControlTemplate>

--- a/Croak/UserProfile.cpp
+++ b/Croak/UserProfile.cpp
@@ -1,0 +1,43 @@
+﻿#include "pch.h"
+#include "UserProfile.h"
+#if __has_include("UserProfile.g.cpp")
+#include "UserProfile.g.cpp"
+#endif
+
+namespace Storage = winrt::Windows::Storage;
+namespace Windowing = winrt::Microsoft::UI::Windowing;
+
+namespace winrt::Croak::implementation
+{
+    void UserProfile::Restore(const Storage::ApplicationDataContainer& container)
+    {
+        hotKeysEnabled = unbox_value<bool>(container.Values().Lookup(L"HotKeysEnabled"));
+        isAlwaysOnTop = unbox_value<bool>(container.Values().Lookup(L"IsAlwaysOnTop"));
+        restoreWindowState = unbox_value<bool>(container.Values().Lookup(L"RestoreWindowState"));
+        presenterState = static_cast<Windowing::OverlappedPresenterState>(
+                unbox_value<int32_t>(container.Values().Lookup(L"PresenterState"))
+            );
+
+        Storage::ApplicationDataCompositeValue composite = unbox_value<Storage::ApplicationDataCompositeValue>(container.Values().Lookup(L"WindowDisplayRect"));
+        int32_t x = unbox_value<int32_t>(composite.Lookup(L"X"));
+        int32_t y = unbox_value<int32_t>(composite.Lookup(L"Y"));
+        int32_t width = unbox_value<int32_t>(composite.Lookup(L"Width"));
+        int32_t height = unbox_value<int32_t>(composite.Lookup(L"Height"));
+        windowDisplayRect = winrt::Windows::Graphics::RectInt32(x, y, width, height);
+    }
+
+    void UserProfile::Save(const Storage::ApplicationDataContainer& container)
+    {
+        container.Values().Insert(L"HotKeysEnabled", box_value(hotKeysEnabled));
+        container.Values().Insert(L"IsAlwaysOnTop", box_value(isAlwaysOnTop));
+        container.Values().Insert(L"RestoreWindowState", box_value(restoreWindowState));
+        container.Values().Insert(L"PresenterState", box_value(static_cast<int32_t>(presenterState)));
+
+        Storage::ApplicationDataCompositeValue composite{};
+        composite.Insert(L"X", winrt::box_value(windowDisplayRect.X));
+        composite.Insert(L"Y", winrt::box_value(windowDisplayRect.Y));
+        composite.Insert(L"Width", winrt::box_value(windowDisplayRect.Width));
+        composite.Insert(L"Height", winrt::box_value(windowDisplayRect.Height));
+        container.Values().Insert(L"WindowDisplayRect", composite);
+    }
+}

--- a/Croak/UserProfile.h
+++ b/Croak/UserProfile.h
@@ -1,0 +1,104 @@
+﻿#pragma once
+
+#include "UserProfile.g.h"
+
+namespace winrt::Croak::implementation
+{
+    struct UserProfile : UserProfileT<UserProfile>
+    {
+    public:
+        UserProfile() = default;
+
+        winrt::Croak::AudioProfile AudioProfile() const
+        {
+            return audioProfile;
+        }
+        void AudioProfile(const winrt::Croak::AudioProfile& value)
+        {
+            audioProfile = value;
+        }
+
+        bool Frozen() const
+        {
+            return frozen;
+        }
+        void Frozen(const bool& value)
+        {
+            frozen = value;
+        }
+
+        bool HotKeysEnabled() const
+        {
+            return hotKeysEnabled;
+        }
+        void HotKeysEnabled(const bool& value)
+        {
+            hotKeysEnabled = value;
+        }
+
+        bool IsAlwaysOnTop() const
+        {
+            return isAlwaysOnTop;
+        }
+        void IsAlwaysOnTop(const bool& value)
+        {
+            isAlwaysOnTop = value;
+        }
+
+        winrt::hstring ProfileName() const
+        {
+            return profileName;
+        }
+        void ProfileName(const winrt::hstring& value)
+        {
+            profileName = value;
+        }
+
+        winrt::Microsoft::UI::Windowing::OverlappedPresenterState PresenterState() const
+        {
+            return presenterState;
+        }
+        void PresenterState(const winrt::Microsoft::UI::Windowing::OverlappedPresenterState& value)
+        {
+            presenterState = value;
+        }
+
+        bool RestoreWindowState() const
+        {
+            return restoreWindowState;
+        }
+        void RestoreWindowState(const bool& value)
+        {
+            restoreWindowState = value;
+        }
+
+        winrt::Windows::Graphics::RectInt32 WindowDisplayRect() const
+        {
+            return windowDisplayRect;
+        }
+        void WindowDisplayRect(const winrt::Windows::Graphics::RectInt32& value)
+        {
+            windowDisplayRect = value;
+        }
+
+        void Restore(const winrt::Windows::Storage::ApplicationDataContainer& container);
+        void Save(const winrt::Windows::Storage::ApplicationDataContainer& containter);
+
+    private:
+        winrt::Croak::AudioProfile audioProfile{};
+        bool frozen = false;
+        bool hotKeysEnabled = true;
+        bool isAlwaysOnTop = false;
+        bool restoreWindowState = false;
+        winrt::Windows::Graphics::RectInt32 windowDisplayRect{};
+        winrt::hstring profileName{};
+        winrt::Microsoft::UI::Windowing::OverlappedPresenterState presenterState = winrt::Microsoft::UI::Windowing::OverlappedPresenterState::Restored;
+    };
+}
+
+namespace winrt::Croak::factory_implementation
+{
+    struct UserProfile : UserProfileT<UserProfile, implementation::UserProfile>
+    {
+    };
+}

--- a/Croak/UserProfile.idl
+++ b/Croak/UserProfile.idl
@@ -1,0 +1,23 @@
+import "AudioProfile.idl";
+
+namespace Croak
+{
+    [bindable]
+    [default_interface]
+    runtimeclass UserProfile 
+    {
+        UserProfile();
+
+        AudioProfile AudioProfile;
+        Boolean Frozen;
+        String ProfileName;
+        Boolean IsAlwaysOnTop;
+        Boolean RestoreWindowState;
+        Windows.Graphics.RectInt32 WindowDisplayRect;
+        Boolean HotKeysEnabled;
+        Microsoft.UI.Windowing.OverlappedPresenterState PresenterState;
+
+        void Restore(Windows.Storage.ApplicationDataContainer container);
+        void Save(Windows.Storage.ApplicationDataContainer container);
+    }
+}

--- a/Croak/pch.h
+++ b/Croak/pch.h
@@ -11,23 +11,25 @@
 #include <comip.h>
 #include <dispatcherqueue.h>
 #include <endpointvolume.h>
+#include <functional>
 #include <hstring.h>
 #include <math.h>
 #include <mmdeviceapi.h>
 #include <mutex>
+#include <objbase.h>
 #include <Psapi.h>
+#include <ppl.h>
+#include <ppltasks.h>
+#include <regex>
 #include <restrictederrorinfo.h>
 #include <rpc.h>
 #include <Shobjidl.h>
 #include <Shlobj.h>
 #include <unknwn.h>
-#include <windows.h>
-#include <objbase.h>
 #include <strsafe.h>
 #include <Shlwapi.h>
 #include <filesystem>
-#include <regex>
-#include <functional>
+#include <windows.h>
 
 
 #ifdef _DEBUG

--- a/update_notes.json
+++ b/update_notes.json
@@ -3,7 +3,7 @@
         "news": [
             {
                 "title": "Overlay",
-                "text": "Overlay mode has been introduced. You can activate it in the menu, next to the Picture-in-picture button."
+                "text": "Overlay mode has been introduced. You can activate it in the menu, next to the Picture-in-picture button. A new hot key has been added to show and hide the window (in normal,compact or overlay mode): Alt + A."
             },
             {
                 "title": "Indicators",
@@ -19,7 +19,8 @@
         ],
         "bugs": [
             "On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.",
-            "Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation."
+            "Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.",
+            "Some applications will be named 'ms-resource:AppStoreName', this is a bug that will be adressed."
         ]
     },
     "fr-FR": {


### PR DESCRIPTION
## Updates
- Added background color (in `OverlaySettingsPage`) to see the size of the screen.
- Moving all audio related logic from MainWindow to AudioViewer (no regression allowed).
- Split user profile in 2:
    - UserProfile to store window properties, overlay settings and stuff like that.
    - AudioProfile to store all audio related settings.
*-> this change was needed to have more flexibility and to clearly split responsabilities between `MainWindow` and `AudioViewer`.*
- Added `UserProfile` to save window and app related settings. `AudioProfile` now handles only audio related settings.
- Removed app/window related settings from `AudioProfile` (ie `IsAlwaysOnTop`, `WindowDisplayRect`).
- Moved MessageBar to the bottom to replicate Youtube's mobile app notifications (and updating animations accordingly).
- Updated `ToggleButton` to use `IInspectable` (to display generic content) for `OnIcon` and `OffIcon`. It might be changed back to `hstring` since icon composition is not that useful.
- `OverlaySettingsPage` now adds itself to the navigation breadcrumbs.

## Fixes
- Fixed audio sessions being added even if another session with the same grouping parameter.
- Fixed `Audio session volume icon is not green when the audio session is active in vertical layout.`
- Fixed `ToggleIconButton` not properly behaving on pointer over by setting its background.

## Bugs
- Audio sessions will need to be reloaded manually after the computer has been put to sleep or hibernation.
- On some computers, pluggin/unplugging an audio jack will crash the app. The issue seems to be coming from the audio driver application.
- Some I18Ned applications don't have a real name: "ms-resource:AppStoreName".